### PR TITLE
Reset state machine during disabled mode

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -84,6 +84,10 @@ public class Robot extends TimedRobot {
   @Override
   public void disabledInit() {
     m_state.setDisabled(true);
+    if (m_autonomousCommand != null && m_autonomousCommand.isScheduled()) {
+      m_autonomousCommand.cancel();
+    }
+    m_state.cancelCurrentCommand();
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/StateSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/StateSubsystem.java
@@ -226,7 +226,10 @@ public class StateSubsystem extends SubsystemBase {
      * Cancels current running command or sequence of commands. Also sets current state to cancelled and sets the subsystems to their current position
      */
     public void cancelCurrentCommand() {
-        currentCommand.cancel();
+        if (currentCommand != null) {
+            currentCommand.cancel();
+            currentCommand = null;
+        }
         setCurrentState(PositionState.Cancelled);
         //setGoal(PositionState.Cancelled);
         goalState = PositionState.Cancelled;


### PR DESCRIPTION
## Summary
- Cancel active commands and reset subsystem state when the robot enters disabled mode
- Safely guard `cancelCurrentCommand` against nulls and clear current command reference

## Testing
- `bash gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c089337f48832f8449442d0d9224bf