### PR TITLE
Add unit tests for differential arm dynamics and sim

### DIFF
--- a/src/test/java/frc/utils/DifferentialArmDynamicsTest.java
+++ b/src/test/java/frc/utils/DifferentialArmDynamicsTest.java
@@ -1,0 +1,229 @@
+package frc.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.ejml.data.Complex_F64;
+import org.ejml.simple.SimpleEVD;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.Nat;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N2;
+import edu.wpi.first.math.numbers.N4;
+import edu.wpi.first.math.system.LinearSystem;
+import edu.wpi.first.math.system.plant.DCMotor;
+
+/** Unit tests for {@link DifferentialArmDynamics}. */
+public class DifferentialArmDynamicsTest {
+  private static final double kEps = 1e-6;
+
+  private DifferentialArmDynamics createDynamics(double gravity, double extensionInclination) {
+    return new DifferentialArmDynamics(
+        1.0, // extension mass
+        1.0, // rotation mass
+        0.2, // rotation inertia
+        0.5, // COM offset
+        extensionInclination,
+        gravity,
+        0.0, // extension viscous damping
+        0.0, // extension coulomb friction
+        0.0, // rotation viscous damping
+        0.0, // rotation coulomb friction
+        DCMotor.getNEO(1),
+        DCMotor.getNEO(1),
+        0.1, // linear drive radius
+        0.1, // differential arm radius
+        0.0, // sensor offset
+        0.0 // motor rotor inertia
+        );
+  }
+
+  @Test
+  public void constructorStoresParameters() throws Exception {
+    DCMotor right = DCMotor.getNEO(1);
+    DCMotor left = DCMotor.getNEO(1);
+    double extensionMass = 2.0;
+    double rotationMass = 3.0;
+    double rotationInertia = 0.7;
+    double comOffset = 0.4;
+    double extensionInclination = 0.3;
+    double gravity = 9.0;
+    double extensionViscous = 0.01;
+    double extensionCoulomb = 0.02;
+    double rotationViscous = 0.03;
+    double rotationCoulomb = 0.04;
+    double linearDriveRadius = 0.05;
+    double diffArmRadius = 0.06;
+    double sensorOffset = 0.07;
+    double rotorInertia = 0.08;
+
+    DifferentialArmDynamics dynamics =
+        new DifferentialArmDynamics(
+            extensionMass,
+            rotationMass,
+            rotationInertia,
+            comOffset,
+            extensionInclination,
+            gravity,
+            extensionViscous,
+            extensionCoulomb,
+            rotationViscous,
+            rotationCoulomb,
+            right,
+            left,
+            linearDriveRadius,
+            diffArmRadius,
+            sensorOffset,
+            rotorInertia);
+
+    assertEquals(right, getField(dynamics, "m_rightMotor"));
+    assertEquals(left, getField(dynamics, "m_leftMotor"));
+    assertEquals(extensionMass, (double) getField(dynamics, "m_extensionMass"), kEps);
+    assertEquals(rotationMass, (double) getField(dynamics, "m_rotationMass"), kEps);
+    assertEquals(rotationInertia, (double) getField(dynamics, "m_rotationInertia"), kEps);
+    assertEquals(comOffset, (double) getField(dynamics, "m_comOffset"), kEps);
+    assertEquals(extensionInclination, (double) getField(dynamics, "m_extensionInclination"), kEps);
+    assertEquals(gravity, (double) getField(dynamics, "m_gravity"), kEps);
+    assertEquals(extensionViscous, (double) getField(dynamics, "m_extensionViscousDamping"), kEps);
+    assertEquals(extensionCoulomb, (double) getField(dynamics, "m_extensionCoulombFriction"), kEps);
+    assertEquals(rotationViscous, (double) getField(dynamics, "m_rotationViscousDamping"), kEps);
+    assertEquals(rotationCoulomb, (double) getField(dynamics, "m_rotationCoulombFriction"), kEps);
+    assertEquals(linearDriveRadius, (double) getField(dynamics, "m_linearDriveRadius"), kEps);
+    assertEquals(diffArmRadius, (double) getField(dynamics, "m_differentialArmRadius"), kEps);
+    assertEquals(sensorOffset, (double) getField(dynamics, "m_sensorOffset"), kEps);
+    assertEquals(rotorInertia, (double) getField(dynamics, "m_motorRotorInertia"), kEps);
+  }
+
+  private Object getField(Object obj, String name) throws Exception {
+    Field f = obj.getClass().getDeclaredField(name);
+    f.setAccessible(true);
+    return f.get(obj);
+  }
+
+  @Test
+  public void zeroInputsZeroGravityNoMotion() {
+    DifferentialArmDynamics dyn = createDynamics(0.0, 0.0);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(0.0, 0.0);
+    Matrix<N4, N1> dx = dyn.dynamics(x, u);
+    assertEquals(0.0, dx.get(1, 0), 1e-9);
+    assertEquals(0.0, dx.get(3, 0), 1e-9);
+  }
+
+  @Test
+  public void gravityCausesArmToFall() {
+    DifferentialArmDynamics dyn = createDynamics(9.81, 0.0);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(0.0, 0.0);
+    Matrix<N4, N1> dx = dyn.dynamics(x, u);
+    assertTrue(dx.get(3, 0) < 0.0);
+  }
+
+  @Test
+  public void gravityCausesExtensionSlide() {
+    // Negative inclination corresponds to axis sloping downward in positive r direction
+    DifferentialArmDynamics dyn = createDynamics(9.81, -0.2);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(0.0, 0.0);
+    Matrix<N4, N1> dx = dyn.dynamics(x, u);
+    assertTrue(dx.get(1, 0) > 0.0);
+  }
+
+  @Test
+  public void opposingVoltagesRotateArm() {
+    DifferentialArmDynamics dyn = createDynamics(0.0, 0.0);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(-5.0, 5.0);
+    Matrix<N4, N1> dx = dyn.dynamics(x, u);
+    assertTrue(dx.get(3, 0) > 0.0);
+    assertEquals(0.0, dx.get(1, 0), 1e-3);
+  }
+
+  @Test
+  public void equalVoltagesExtendArm() {
+    DifferentialArmDynamics dyn = createDynamics(0.0, 0.0);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(5.0, 5.0);
+    Matrix<N4, N1> dx = dyn.dynamics(x, u);
+    assertTrue(dx.get(1, 0) > 0.0);
+    assertEquals(0.0, dx.get(3, 0), 1e-3);
+  }
+
+  @Test
+  public void feedforwardHoldsHorizontal() {
+    DifferentialArmDynamics dyn = createDynamics(9.81, 0.0);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> ff = dyn.calculateFeedforward(x);
+    assertNotEquals(0.0, ff.get(0, 0), kEps);
+    assertNotEquals(0.0, ff.get(1, 0), kEps);
+    Matrix<N4, N1> dx = dyn.dynamics(x, ff);
+    assertEquals(0.0, dx.get(1, 0), 1e-6);
+    assertEquals(0.0, dx.get(3, 0), 1e-6);
+  }
+
+  @Test
+  public void feedforwardVerticalHasNoRotationComponent() {
+    DifferentialArmDynamics dyn = createDynamics(9.81, 0.0);
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, -Math.PI / 2.0, 0.0);
+    Matrix<N2, N1> ff = dyn.calculateFeedforward(x);
+    assertEquals(ff.get(0, 0), ff.get(1, 0), 1e-6);
+  }
+
+  @Test
+  public void linearizedSystemHasCorrectDimensions() {
+    DifferentialArmDynamics dyn = createDynamics(9.81, 0.0);
+    LinearSystem<N4, N2, N4> sys = dyn.createLinearizedSystem(0.5, -Math.PI / 2.0);
+    Matrix<N4, N4> A = sys.getA();
+    Matrix<N4, N2> B = sys.getB();
+    assertEquals(4, A.getNumRows());
+    assertEquals(4, A.getNumCols());
+    assertEquals(4, B.getNumRows());
+    assertEquals(2, B.getNumCols());
+  }
+
+  @Test
+  public void equilibriumLinearizationIsStable() {
+    DifferentialArmDynamics dyn = createDynamics(9.81, 0.0);
+    LinearSystem<N4, N2, N4> sys = dyn.createLinearizedSystem(0.5, -Math.PI / 2.0);
+    SimpleEVD<?> evd = sys.getA().getStorage().eig();
+    for (int i = 0; i < evd.getNumberOfEigenvalues(); i++) {
+      Complex_F64 eig = evd.getEigenvalue(i);
+      assertTrue(eig.getReal() <= kEps);
+    }
+  }
+
+  @Test
+  public void stallCurrentMatchesMotorModel() {
+    DifferentialArmDynamics dyn = createDynamics(0.0, 0.0);
+    DCMotor motor = DCMotor.getNEO(1);
+    double volts = 2.0;
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, 0.0, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(volts, volts);
+    double expected = volts / motor.rOhms;
+    double iR = dyn.getRightMotorCurrentAmps(x, u);
+    double iL = dyn.getLeftMotorCurrentAmps(x, u);
+    assertEquals(expected, iR, 1e-6);
+    assertEquals(expected, iL, 1e-6);
+    assertEquals(Math.abs(iR) + Math.abs(iL), dyn.getTotalCurrentAbsAmps(x, u), 1e-6);
+  }
+
+  @Test
+  public void freeSpeedCurrentNearFreeCurrent() {
+    DifferentialArmDynamics dyn = createDynamics(0.0, 0.0);
+    DCMotor motor = DCMotor.getNEO(1);
+    double v = motor.nominalVoltageVolts;
+    double omega = motor.freeSpeedRadPerSec;
+    double rDot = omega * 0.1; // linearDriveRadius
+    Matrix<N4, N1> x = VecBuilder.fill(0.0, rDot, 0.0, 0.0);
+    Matrix<N2, N1> u = VecBuilder.fill(v, v);
+    double iR = dyn.getRightMotorCurrentAmps(x, u);
+    double iL = dyn.getLeftMotorCurrentAmps(x, u);
+    assertEquals(motor.freeCurrentAmps, iR, 0.5);
+    assertEquals(motor.freeCurrentAmps, iL, 0.5);
+    assertEquals(Math.abs(iR) + Math.abs(iL), dyn.getTotalCurrentAbsAmps(x, u), 0.5);
+  }
+}

--- a/src/test/java/frc/utils/DifferentialArmSimTest.java
+++ b/src/test/java/frc/utils/DifferentialArmSimTest.java
@@ -1,0 +1,155 @@
+package frc.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N2;
+import edu.wpi.first.math.numbers.N4;
+import edu.wpi.first.math.system.plant.DCMotor;
+import java.lang.reflect.Field;
+
+/** Unit tests for {@link DifferentialArmSim}. */
+public class DifferentialArmSimTest {
+  private static final double kMinExtension = 0.0;
+  private static final double kMaxExtension = 1.0;
+  private static final double kMinTheta = -Math.PI / 2.0;
+  private static final double kMaxTheta = Math.PI / 2.0;
+
+  private DifferentialArmSim createSim(double gravity) {
+    return new DifferentialArmSim(
+        1.0,
+        1.0,
+        0.2,
+        0.5,
+        0.0,
+        gravity,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        DCMotor.getNEO(1),
+        DCMotor.getNEO(1),
+        0.1,
+        0.1,
+        0.0,
+        0.0,
+        kMinExtension,
+        kMaxExtension,
+        kMinTheta,
+        kMaxTheta,
+        0.5,
+        0.0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T getSimField(DifferentialArmSim sim, String name) throws Exception {
+    Field f = edu.wpi.first.wpilibj.simulation.LinearSystemSim.class.getDeclaredField(name);
+    f.setAccessible(true);
+    return (T) f.get(sim);
+  }
+
+  private void setInternalState(DifferentialArmSim sim, int index, double value) throws Exception {
+    Matrix<N4, N1> x = getSimField(sim, "m_x");
+    Matrix<N4, N1> y = getSimField(sim, "m_y");
+    x.set(index, 0, value);
+    y.set(index, 0, value);
+  }
+
+  @Test
+  public void constructorSetsInitialState() {
+    DifferentialArmSim sim = createSim(0.0);
+    assertEquals(0.5, sim.getExtensionPositionMeters(), 1e-9);
+    assertEquals(0.0, sim.getRotationAngleRads(), 1e-9);
+  }
+
+  @Test
+  public void maxExtensionClampsAndStops() {
+    DifferentialArmSim sim = createSim(0.0);
+    sim.setState(kMaxExtension - 0.01, 1.0, 0.0, 0.0);
+    sim.setInputVoltage(0.0, 0.0);
+    sim.update(0.02);
+    assertEquals(kMaxExtension, sim.getExtensionPositionMeters(), 1e-9);
+    assertEquals(0.0, sim.getExtensionVelocityMetersPerSec(), 1e-9);
+  }
+
+  @Test
+  public void minAngleClampsAndStops() {
+    DifferentialArmSim sim = createSim(9.81);
+    sim.setState(0.5, 0.0, kMinTheta + 0.01, -1.0);
+    sim.setInputVoltage(0.0, 0.0);
+    sim.update(0.02);
+    assertEquals(kMinTheta, sim.getRotationAngleRads(), 1e-9);
+    assertEquals(0.0, sim.getRotationVelocityRadsPerSec(), 1e-9);
+  }
+
+  @Test
+  public void setStateClampsWithinLimits() {
+    DifferentialArmSim sim = createSim(0.0);
+    sim.setState(kMinExtension - 5.0, 0.0, kMinTheta - 5.0, 0.0);
+    assertEquals(kMinExtension, sim.getExtensionPositionMeters(), 1e-9);
+    assertEquals(kMinTheta, sim.getRotationAngleRads(), 1e-9);
+    sim.setState(kMaxExtension + 5.0, 0.0, kMaxTheta + 5.0, 0.0);
+    assertEquals(kMaxExtension, sim.getExtensionPositionMeters(), 1e-9);
+    assertEquals(kMaxTheta, sim.getRotationAngleRads(), 1e-9);
+  }
+
+  @Test
+  public void inputVoltageUpdatesInternalVector() throws Exception {
+    DifferentialArmSim sim = createSim(0.0);
+    sim.setInputVoltage(2.5, -3.0);
+    Matrix<N2, N1> u = getSimField(sim, "m_u");
+    assertEquals(2.5, u.get(0, 0), 1e-9);
+    assertEquals(-3.0, u.get(1, 0), 1e-9);
+  }
+
+  @Test
+  public void hasHitMinExtensionWorks() throws Exception {
+    DifferentialArmSim sim = createSim(0.0);
+    double eps = 1e-4;
+    setInternalState(sim, 0, kMinExtension - eps);
+    assertTrue(sim.hasHitMinExtension());
+    setInternalState(sim, 0, kMinExtension);
+    assertTrue(sim.hasHitMinExtension());
+    setInternalState(sim, 0, kMinExtension + eps);
+    assertFalse(sim.hasHitMinExtension());
+  }
+
+  @Test
+  public void hasHitMaxExtensionWorks() throws Exception {
+    DifferentialArmSim sim = createSim(0.0);
+    double eps = 1e-4;
+    setInternalState(sim, 0, kMaxExtension + eps);
+    assertTrue(sim.hasHitMaxExtension());
+    setInternalState(sim, 0, kMaxExtension);
+    assertTrue(sim.hasHitMaxExtension());
+    setInternalState(sim, 0, kMaxExtension - eps);
+    assertFalse(sim.hasHitMaxExtension());
+  }
+
+  @Test
+  public void hasHitMinAngleWorks() throws Exception {
+    DifferentialArmSim sim = createSim(0.0);
+    double eps = 1e-4;
+    setInternalState(sim, 2, kMinTheta - eps);
+    assertTrue(sim.hasHitMinAngle());
+    setInternalState(sim, 2, kMinTheta);
+    assertTrue(sim.hasHitMinAngle());
+    setInternalState(sim, 2, kMinTheta + eps);
+    assertFalse(sim.hasHitMinAngle());
+  }
+
+  @Test
+  public void hasHitMaxAngleWorks() throws Exception {
+    DifferentialArmSim sim = createSim(0.0);
+    double eps = 1e-4;
+    setInternalState(sim, 2, kMaxTheta + eps);
+    assertTrue(sim.hasHitMaxAngle());
+    setInternalState(sim, 2, kMaxTheta);
+    assertTrue(sim.hasHitMaxAngle());
+    setInternalState(sim, 2, kMaxTheta - eps);
+    assertFalse(sim.hasHitMaxAngle());
+  }
+}


### PR DESCRIPTION
## Summary
- add comprehensive tests for DifferentialArmDynamics covering dynamics, feedforward, linearization, and currents
- add tests for DifferentialArmSim verifying state handling, limit clamping, input management, and limit detection

## Testing
- `./gradlew --console=plain test`


------
https://chatgpt.com/codex/tasks/task_e_68c16a5cc280832fb87f3dfc4230bbd5