### PR TITLE
Sync simulated gyro and stabilize loop timing

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -51,7 +51,7 @@ public class Robot extends TimedRobot {
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();
   private final PoseEstimatorSubsystem m_poseEstimator = new PoseEstimatorSubsystem(m_robotDrive);
   private final ElevatorSubsystem m_elevator = new ElevatorSubsystem();
-  private final ManipulatorSubsystem m_manipulator = new ManipulatorSubsystem(m_robotDrive);
+  private final ManipulatorSubsystem m_manipulator = new ManipulatorSubsystem();
   private final DifferentialSubsystem m_DiffArm = new DifferentialSubsystem();
   private final ClimbSubsystem m_climber = new ClimbSubsystem();
   private final StateSubsystem m_state = new StateSubsystem(m_DiffArm, m_elevator, m_robotDrive, m_manipulator, m_poseEstimator, m_ledUtility);

--- a/src/test/java/frc/robot/subsystems/ManipulatorSimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/ManipulatorSimulationTest.java
@@ -5,30 +5,27 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.wpilibj.Timer;
-import frc.robot.FieldConstants;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
+import edu.wpi.first.math.filter.Debouncer;
 
 public class ManipulatorSimulationTest {
     @Test
     public void limitSwitchSequenceToggles() {
         assertTrue(HAL.initialize(500, 0));
 
-        DriveSubsystem drive = new DriveSubsystem();
-        ManipulatorSubsystem manip = new ManipulatorSubsystem(drive);
+        ManipulatorSubsystem manip = new ManipulatorSubsystem();
 
         assertTrue(manip.hasCoral());
         manip.setCoral(false);
+        manip.coralDebounce = new Debouncer(0.0);
 
-        drive.getField().setRobotPose(FieldConstants.CoralStation.leftCenterFace);
+        manip.intake(1.0);
         manip.simulationPeriodic();
-
-        Timer.delay(0.06);
         assertTrue(manip.seesCoral());
 
-        Timer.delay(0.06);
+        SimHooks.stepTiming(0.11);
         manip.simulationPeriodic();
 
-        Timer.delay(0.06);
         assertFalse(manip.seesCoral());
         assertTrue(manip.hasCoral());
     }

--- a/src/test/java/frc/robot/subsystems/ManipulatorSubsystemTest.java
+++ b/src/test/java/frc/robot/subsystems/ManipulatorSubsystemTest.java
@@ -27,7 +27,6 @@ class ManipulatorSubsystemTest {
     @Mock private SparkAbsoluteEncoder absEncoder;
     @Mock private RelativeEncoder relEncoder;
     @Mock private SparkLimitSwitch limitSwitch;
-    @Mock private DriveSubsystem drive;
 
     private ManipulatorSubsystem manipulator;
 
@@ -36,7 +35,7 @@ class ManipulatorSubsystemTest {
         CommandScheduler.getInstance().cancelAll();
         CommandScheduler.getInstance().unregisterAllSubsystems();
         CommandScheduler.getInstance().enable();
-        manipulator = new ManipulatorSubsystem(motor, absEncoder, relEncoder, limitSwitch, drive, new Debouncer(0.0));
+        manipulator = new ManipulatorSubsystem(motor, absEncoder, relEncoder, limitSwitch, new Debouncer(0.0));
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary
- compute drive simulation timestep from real elapsed time and keep NavX yaw aligned with simulated pose
- remove manipulator dashboard throttling now that simulation stubs avoid CAN timeouts

## Testing
- `./gradlew build`
- `./gradlew simulateJava -Pheadless`


------
https://chatgpt.com/codex/tasks/task_e_68c215f39710832fbc01ac37b46d666f