### PR TITLE
Pass controllers to swerve module sim

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj.simulation.DriverStationSim;
 import edu.wpi.first.wpilibj.simulation.JoystickSim;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.subsystems.ClimbSubsystem;
@@ -121,9 +122,17 @@ public class Robot extends TimedRobot {
     Pose2d pose = m_robotDrive.getField().getRobotPose();
     if (m_frontVisionSim != null) {
       m_frontVisionSim.updateSim(pose, 0.02);
+      m_poseEstimator.addVisionMeasurement(
+          m_frontVisionSim.getCamera().getLatestResult(),
+          VisionConstants.APRILTAG_CAMERA_TO_ROBOT,
+          Timer.getFPGATimestamp());
     }
     if (m_rearVisionSim != null) {
       m_rearVisionSim.updateSim(pose, 0.02);
+      m_poseEstimator.addVisionMeasurement(
+          m_rearVisionSim.getCamera().getLatestResult(),
+          VisionConstants.APRILTAG_CAMERA2_TO_ROBOT,
+          Timer.getFPGATimestamp());
     }
 
     totalCurrentDraw =

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -158,9 +158,9 @@ public class DriveSubsystem extends SubsystemBase {
                     module.getTurnSim() != null ? ModuleConstants.kSteerMotor : null,
                     ModuleConstants.kSteerReduction,
                     module.getDriveSim(),
-                    null,
+                    module.getDrivingController(),
                     module.getTurnSim(),
-                    null);
+                    module.getTurningController());
             }
 
             swerveSim = new SwerveDriveSim(

--- a/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
@@ -228,6 +228,16 @@ public class MAXSwerveModule {
         return turnSim;
     }
 
+    /** Returns the closed-loop controller for the driving motor. */
+    public SparkClosedLoopController getDrivingController() {
+        return m_drivingClosedLoopController;
+    }
+
+    /** Returns the closed-loop controller for the turning motor. */
+    public SparkClosedLoopController getTurningController() {
+        return m_turningClosedLoopController;
+    }
+
     /** Returns the most recently commanded state for this module. */
     public SwerveModuleState getDesiredState() {
         return m_desiredState;

--- a/src/main/java/frc/utils/VisionSim.java
+++ b/src/main/java/frc/utils/VisionSim.java
@@ -10,6 +10,8 @@ import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.VisionConstants;
 
 /** Simple wrapper around PhotonVision simulation objects. */
@@ -17,6 +19,7 @@ public class VisionSim {
     private final PhotonCamera camera;
     private final PhotonCameraSim cameraSim;
     private final VisionSystemSim visionSim;
+    private final SwerveDriveKinematics KINEMATICS = DriveConstants.kDriveKinematics;
 
     public VisionSim(String cameraName, Transform3d robotToCamera) {
         camera = new PhotonCamera(cameraName);


### PR DESCRIPTION
## Summary
- expose swerve module drive and turn controllers
- wire drive subsystem's simulation with the module controllers
- switch vision sim to swerve kinematics and forward raw results to centralized pose estimator

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c357335868832f97061ba9b2136ed7