### PR TITLE
Gate CAN bridge for simulation

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -65,7 +65,9 @@ public class Robot extends TimedRobot {
   private double loadedBatteryVoltage;
 
   public Robot() {
-    CanBridge.runTCP();
+    if (RobotBase.isReal()) {
+      CanBridge.runTCP();
+    }
   }
 
   /**
@@ -80,8 +82,8 @@ public class Robot extends TimedRobot {
       DriverStationSim.setJoystickButtonCount(OIConstants.kDriverControllerPort, 12);
       DriverStationSim.setJoystickPOVCount(OIConstants.kDriverControllerPort, 1);
       new JoystickSim(OIConstants.kDriverControllerPort);
-      DriverStationSim.setAutonomous(false);
-      DriverStationSim.setEnabled(false);
+      DriverStationSim.setAutonomous(true);
+      DriverStationSim.setEnabled(true);
       DriverStationSim.notifyNewData();
     }
 


### PR DESCRIPTION
## Summary
- Wrap CanBridge startup in Robot constructor with RobotBase.isReal to avoid blocking simulation
- Enable and set autonomous mode on DriverStationSim in robotInit so simulated robot code executes

## Testing
- `./gradlew build`
- `./gradlew simulateJava`


------
https://chatgpt.com/codex/tasks/task_e_68c38a9f4a54832fae501a34c2390fc6