### PR TITLE
Model steering and drive velocity in SwerveModuleSim

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -56,9 +56,14 @@ public final class Constants {
         public static final double climberInSetpoint = -85;
 
         // Simulation parameters
-        public static final double kSimGearing = 20.0; // motor to drum ratio
-        public static final double kSimDrumRadiusMeters = 0.02; // m
-        public static final double kSimCarriageMassKg = 5.0; // kg
+        // Gear reduction between motor and climber arm
+        public static final double kSimGearing = 250.0;
+        // Approximate length of the climber arm (meters)
+        public static final double kSimArmLengthMeters = 0.25;
+        // Mass of the arm when deploying (kg)
+        public static final double kSimDeployMassKg = 5.0;
+        // Mass of the arm plus robot when retracting (kg)
+        public static final double kSimRetractMassKg = 55.0;
     }
 
     public static final class Elevator {

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -16,6 +16,8 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.SimDeviceSim;
 import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.wpilibj.simulation.BatterySim;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -24,7 +26,6 @@ import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.RobotBase;
-import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -295,7 +296,7 @@ public class DriveSubsystem extends SubsystemBase {
             return;
         }
 
-        double batteryVoltage = RobotController.getBatteryVoltage();
+        double batteryVoltage = RoboRioSim.getVInVoltage();
         SwerveModuleSim.ModuleForce[] forces = new SwerveModuleSim.ModuleForce[m_moduleSims.length];
         var speeds = swerveDriveSim.getSpeeds();
         double[] offsets = {
@@ -338,6 +339,9 @@ public class DriveSubsystem extends SubsystemBase {
         actVxPublisher.set(actual.vxMetersPerSecond);
         actVyPublisher.set(actual.vyMetersPerSecond);
         actOmegaPublisher.set(actual.omegaRadiansPerSecond);
+
+        RoboRioSim.setVInVoltage(
+            BatterySim.calculateDefaultBatteryLoadedVoltage(getCurrentDraw()));
     }
 
     public void setSlowSpeed() {

--- a/src/test/java/frc/robot/subsystems/ClimbSubsystemTest.java
+++ b/src/test/java/frc/robot/subsystems/ClimbSubsystemTest.java
@@ -131,4 +131,11 @@ class ClimbSubsystemTest {
         when(servo.getPosition()).thenReturn(0.25);
         assertEquals(0.25, climb.getServoPos(), 1e-9);
     }
+
+    @Test
+    void ratchetPreventsDeploySpeed() {
+        climb.setServoClose();
+        climb.setClimberSpeed(-0.5);
+        verify(motor).set(0.0);
+    }
 }

--- a/src/test/java/frc/robot/subsystems/ClimberSimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/ClimberSimulationTest.java
@@ -1,0 +1,80 @@
+package frc.robot.subsystems;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import com.revrobotics.sim.SparkMaxSim;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
+
+public class ClimberSimulationTest {
+  @Test
+  public void simSelectsMassBasedOnDirection() throws Exception {
+    HAL.initialize(500, 0);
+
+    SimHooks.restartTiming();
+    ClimbSubsystem climb = new ClimbSubsystem();
+    climb.setServoOpen();
+    Field simField = ClimbSubsystem.class.getDeclaredField("climberSim");
+    simField.setAccessible(true);
+    SparkMaxSim sim = (SparkMaxSim) simField.get(climb);
+    Field armField = ClimbSubsystem.class.getDeclaredField("armSim");
+    armField.setAccessible(true);
+    Field deployField = ClimbSubsystem.class.getDeclaredField("deploySim");
+    deployField.setAccessible(true);
+    Field retractField = ClimbSubsystem.class.getDeclaredField("retractSim");
+    retractField.setAccessible(true);
+
+    sim.setAppliedOutput(0.5);
+    climb.simulationPeriodic();
+    assertSame(deployField.get(climb), armField.get(climb));
+
+    sim.setAppliedOutput(-0.5);
+    climb.simulationPeriodic();
+    assertSame(retractField.get(climb), armField.get(climb));
+
+    Field servoField = ClimbSubsystem.class.getDeclaredField("servo");
+    servoField.setAccessible(true);
+    ((edu.wpi.first.wpilibj.Servo) servoField.get(climb)).close();
+    Field motorField = ClimbSubsystem.class.getDeclaredField("leftMotor");
+    motorField.setAccessible(true);
+    ((com.revrobotics.spark.SparkMax) motorField.get(climb)).close();
+  }
+
+  @Test
+  public void ratchetBlocksDeploy() throws Exception {
+    HAL.initialize(500, 0);
+
+    SimHooks.restartTiming();
+    ClimbSubsystem climb = new ClimbSubsystem();
+    Field f = ClimbSubsystem.class.getDeclaredField("climberSim");
+    f.setAccessible(true);
+    SparkMaxSim sim = (SparkMaxSim) f.get(climb);
+
+    climb.setServoClose();
+    sim.setAppliedOutput(1.0);
+    for (int i = 0; i < 50; i++) {
+      climb.simulationPeriodic();
+      SimHooks.stepTiming(0.02);
+    }
+    assertEquals(0.0, climb.getClimberPos(), 1e-5);
+
+    sim.setAppliedOutput(-1.0);
+    for (int i = 0; i < 50; i++) {
+      climb.simulationPeriodic();
+      SimHooks.stepTiming(0.02);
+    }
+    assertTrue(Math.abs(climb.getClimberPos()) > 0.0);
+
+    Field servoField = ClimbSubsystem.class.getDeclaredField("servo");
+    servoField.setAccessible(true);
+    ((edu.wpi.first.wpilibj.Servo) servoField.get(climb)).close();
+    Field motorField = ClimbSubsystem.class.getDeclaredField("leftMotor");
+    motorField.setAccessible(true);
+    ((com.revrobotics.spark.SparkMax) motorField.get(climb)).close();
+  }
+}

--- a/src/test/java/frc/robot/subsystems/DifferentialArmSimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/DifferentialArmSimulationTest.java
@@ -1,0 +1,141 @@
+package frc.robot.subsystems;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
+
+import com.revrobotics.RelativeEncoder;
+import com.revrobotics.sim.SparkMaxSim;
+import com.revrobotics.sim.SparkRelativeEncoderSim;
+import com.revrobotics.spark.SparkClosedLoopController;
+import com.revrobotics.spark.SparkMax;
+import com.revrobotics.spark.SparkLowLevel.MotorType;
+import com.revrobotics.spark.config.SparkMaxConfig;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
+import frc.robot.Constants.DifferentialArm;
+import frc.utils.DifferentialArmSim;
+
+/** Tests for the differential arm simulation model. */
+public class DifferentialArmSimulationTest {
+
+  private static class DifferentialArmRig implements AutoCloseable {
+    final DifferentialSubsystem diff;
+    final SparkMax leftMotor;
+    final SparkMax rightMotor;
+    final SparkMaxSim leftSim;
+    final SparkMaxSim rightSim;
+
+    DifferentialArmRig() throws Exception {
+      leftMotor = new SparkMax(100, MotorType.kBrushless);
+      rightMotor = new SparkMax(101, MotorType.kBrushless);
+
+      // minimal configuration to enable encoder sims
+      SparkMaxConfig cfg = new SparkMaxConfig();
+      leftMotor.configure(
+          cfg,
+          com.revrobotics.spark.SparkBase.ResetMode.kNoResetSafeParameters,
+          com.revrobotics.spark.SparkBase.PersistMode.kNoPersistParameters);
+      rightMotor.configure(
+          cfg,
+          com.revrobotics.spark.SparkBase.ResetMode.kNoResetSafeParameters,
+          com.revrobotics.spark.SparkBase.PersistMode.kNoPersistParameters);
+
+      RelativeEncoder leftEnc = leftMotor.getEncoder();
+      RelativeEncoder rightEnc = rightMotor.getEncoder();
+      SparkClosedLoopController leftCtrl = leftMotor.getClosedLoopController();
+      SparkClosedLoopController rightCtrl = rightMotor.getClosedLoopController();
+
+      diff =
+          new DifferentialSubsystem(
+              leftMotor, rightMotor, leftEnc, rightEnc, leftCtrl, rightCtrl, null);
+
+      DifferentialArmSim armSim =
+          new DifferentialArmSim(
+              DifferentialArm.kSimExtensionMassKg,
+              DifferentialArm.kSimRotationMassKg,
+              DifferentialArm.kSimRotationInertiaKgM2,
+              DifferentialArm.kSimComOffsetMeters,
+              DifferentialArm.kSimExtensionInclinationRads,
+              0.0,
+              DifferentialArm.kSimExtensionViscousDamping,
+              0.0,
+              DifferentialArm.kSimRotationViscousDamping,
+              0.0,
+              DCMotor.getNEO(1),
+              DCMotor.getNEO(1),
+              DifferentialArm.kSimLinearDriveRadiusMeters,
+              DifferentialArm.kSimDifferentialArmRadiusMeters,
+              DifferentialArm.kSimSensorOffsetRads,
+              DifferentialArm.kSimMotorRotorInertia,
+              DifferentialArm.kSimMinExtensionMeters,
+              DifferentialArm.kSimMaxExtensionMeters,
+              DifferentialArm.kSimMinThetaRads,
+              DifferentialArm.kSimMaxThetaRads,
+              DifferentialArm.kSimStartingExtensionMeters,
+              DifferentialArm.kSimStartingThetaRads);
+
+      leftSim = new SparkMaxSim(leftMotor, DCMotor.getNEO(1));
+      rightSim = new SparkMaxSim(rightMotor, DCMotor.getNEO(1));
+      SparkRelativeEncoderSim leftEncSim = leftSim.getRelativeEncoderSim();
+      SparkRelativeEncoderSim rightEncSim = rightSim.getRelativeEncoderSim();
+
+      Field armSimField = DifferentialSubsystem.class.getDeclaredField("armSim");
+      Field leftSimField = DifferentialSubsystem.class.getDeclaredField("leftSim");
+      Field rightSimField = DifferentialSubsystem.class.getDeclaredField("rightSim");
+      Field leftEncSimField = DifferentialSubsystem.class.getDeclaredField("leftEncoderSim");
+      Field rightEncSimField = DifferentialSubsystem.class.getDeclaredField("rightEncoderSim");
+      armSimField.setAccessible(true);
+      leftSimField.setAccessible(true);
+      rightSimField.setAccessible(true);
+      leftEncSimField.setAccessible(true);
+      rightEncSimField.setAccessible(true);
+      armSimField.set(diff, armSim);
+      leftSimField.set(diff, leftSim);
+      rightSimField.set(diff, rightSim);
+      leftEncSimField.set(diff, leftEncSim);
+      rightEncSimField.set(diff, rightEncSim);
+    }
+
+    @Override
+    public void close() {
+      leftMotor.close();
+      rightMotor.close();
+    }
+  }
+
+  @Test
+  public void motorsTogetherExtendArm() throws Exception {
+    assertTrue(HAL.initialize(500, 0));
+    try (DifferentialArmRig rig = new DifferentialArmRig()) {
+      for (int i = 0; i < 50; i++) {
+        rig.leftSim.setAppliedOutput(1.0);
+        rig.rightSim.setAppliedOutput(1.0);
+        rig.diff.simulationPeriodic();
+        SimHooks.stepTiming(0.02);
+      }
+
+      assertTrue(rig.diff.getExtensionPosition() > 0.0);
+    }
+  }
+
+  @Test
+  public void motorsOppositeRotateArm() throws Exception {
+    assertTrue(HAL.initialize(500, 0));
+    try (DifferentialArmRig rig = new DifferentialArmRig()) {
+      for (int i = 0; i < 50; i++) {
+        rig.leftSim.setAppliedOutput(1.0);
+        rig.rightSim.setAppliedOutput(-1.0);
+        rig.diff.simulationPeriodic();
+        SimHooks.stepTiming(0.02);
+      }
+
+      assertTrue(Math.abs(rig.diff.getRotationPosition()) > 1.0);
+    }
+  }
+}
+

--- a/src/test/java/frc/robot/subsystems/ElevatorSimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/ElevatorSimulationTest.java
@@ -8,19 +8,31 @@ import org.junit.jupiter.api.Test;
 
 import edu.wpi.first.hal.HAL;
 import com.revrobotics.sim.SparkRelativeEncoderSim;
+import edu.wpi.first.wpilibj.simulation.SimHooks;
 
 public class ElevatorSimulationTest {
-    @Test
-    public void simulatedEncoderFeedsPosition() throws Exception {
-        assertTrue(HAL.initialize(500, 0));
+  @Test
+  public void elevatorSimulationFeedsBack() throws Exception {
+    assertTrue(HAL.initialize(500, 0));
 
-        ElevatorSubsystem elevator = new ElevatorSubsystem();
+    ElevatorSubsystem elevator = new ElevatorSubsystem();
 
-        Field simField = ElevatorSubsystem.class.getDeclaredField("leftEncoderSim");
-        simField.setAccessible(true);
-        SparkRelativeEncoderSim encSim = (SparkRelativeEncoderSim) simField.get(elevator);
+    Field simField = ElevatorSubsystem.class.getDeclaredField("leftEncoderSim");
+    simField.setAccessible(true);
+    SparkRelativeEncoderSim encSim = (SparkRelativeEncoderSim) simField.get(elevator);
 
-        encSim.setPosition(0.4);
-        assertEquals(0.4, elevator.getPosition(), 1e-5);
+    encSim.setPosition(0.4);
+    assertEquals(0.4, elevator.getPosition(), 1e-5);
+
+    Field simMotorField = ElevatorSubsystem.class.getDeclaredField("leftSim");
+    simMotorField.setAccessible(true);
+    com.revrobotics.sim.SparkFlexSim sim =
+        (com.revrobotics.sim.SparkFlexSim) simMotorField.get(elevator);
+    for (int i = 0; i < 50; i++) {
+      sim.setAppliedOutput(1.0);
+      elevator.simulationPeriodic();
+      SimHooks.stepTiming(0.02);
     }
+    assertTrue(elevator.getPosition() > 0.0);
+  }
 }


### PR DESCRIPTION
## Summary
- model steering motion using DCMotorSim instead of free-speed model
- feed motor RPM to REV Spark simulators for drive and steer sides
- simulate manipulator and elevator with WPILib physics and mirror encoder state
- simulate differential arm with Spark MAX models and custom dynamics
- add differential arm tests verifying extension vs. rotation with gravity and friction disabled
- simulate climber with separate deploy/retract masses and ratchet-locked servo
- correct climber arm simulation parameters
- simulate drive and manipulator battery sag using REVLib current draw

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c42390ea00832fb29ee129456cdf4d