### PR TITLE
Fix Spark sim bus voltage usage

### DIFF
--- a/src/main/java/frc/robot/subsystems/ClimbSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimbSubsystem.java
@@ -22,6 +22,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.Servo;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
@@ -244,7 +245,7 @@ public class ClimbSubsystem extends SubsystemBase {
     @Override
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && climberSim != null && armSim != null) {
-            double busVoltage = RoboRioSim.getVInVoltage();
+            double busVoltage = RobotController.getBatteryVoltage();
             double appliedVoltage = climberSim.getAppliedOutput() * busVoltage;
             boolean retracting = appliedVoltage < 0.0;
 

--- a/src/main/java/frc/robot/subsystems/DifferentialSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DifferentialSubsystem.java
@@ -23,6 +23,7 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.math.util.Units;
@@ -360,7 +361,7 @@ public class DifferentialSubsystem extends SubsystemBase {
     @Override
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && armSim != null && leftSim != null && rightSim != null) {
-            double busVoltage = RoboRioSim.getVInVoltage();
+            double busVoltage = RobotController.getBatteryVoltage();
 
             double leftVolts = leftSim.getAppliedOutput() * busVoltage;
             double rightVolts = rightSim.getAppliedOutput() * busVoltage;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -26,6 +26,7 @@ import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -296,7 +297,7 @@ public class DriveSubsystem extends SubsystemBase {
             return;
         }
 
-        double batteryVoltage = RoboRioSim.getVInVoltage();
+        double batteryVoltage = RobotController.getBatteryVoltage();
         SwerveModuleSim.ModuleForce[] forces = new SwerveModuleSim.ModuleForce[m_moduleSims.length];
         var speeds = swerveDriveSim.getSpeeds();
         double[] offsets = {

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -18,6 +18,7 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
@@ -225,7 +226,7 @@ public class ElevatorSubsystem extends SubsystemBase {
     @Override
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && leftSim != null && elevatorModel != null) {
-            double busVoltage = RoboRioSim.getVInVoltage();
+            double busVoltage = RobotController.getBatteryVoltage();
 
             elevatorModel.setInputVoltage(leftSim.getAppliedOutput() * busVoltage);
             elevatorModel.update(0.02);

--- a/src/main/java/frc/robot/subsystems/ManipulatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ManipulatorSubsystem.java
@@ -19,6 +19,7 @@ import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
@@ -197,7 +198,7 @@ public class ManipulatorSubsystem extends SubsystemBase {
     @Override
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && manipSim != null && motorModel != null) {
-            double busVoltage = RoboRioSim.getVInVoltage();
+            double busVoltage = RobotController.getBatteryVoltage();
             motorModel.setInputVoltage(manipSim.getAppliedOutput() * busVoltage);
             motorModel.update(0.02);
 

--- a/src/test/java/frc/robot/subsystems/BatterySimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/BatterySimulationTest.java
@@ -1,0 +1,113 @@
+package frc.robot.subsystems;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.revrobotics.spark.SparkBase;
+
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+
+/**
+ * Ensures that subsystem motor simulations draw their bus voltage from the
+ * robot controller's battery simulation.
+ */
+public class BatterySimulationTest {
+  @BeforeAll
+  public static void setupHAL() {
+    assertTrue(HAL.initialize(500, 0));
+  }
+
+  @Test
+  public void motorsFollowRobotControllerBatteryVoltage() throws Exception {
+    // Drive subsystem
+    DriveSubsystem drive = new DriveSubsystem();
+    verifySubsystem(drive, collectDriveMotors(drive));
+
+    // Climb subsystem
+    ClimbSubsystem climb = new ClimbSubsystem();
+    verifySubsystem(climb, List.of(getMotor(climb, "leftMotor")));
+    closeIfPresent(climb, "servo");
+
+    // Differential arm
+    DifferentialSubsystem diff = new DifferentialSubsystem();
+    verifySubsystem(diff, List.of(
+        getMotor(diff, "leftMotor"),
+        getMotor(diff, "rightMotor")));
+
+    // Elevator
+    ElevatorSubsystem elevator = new ElevatorSubsystem();
+    verifySubsystem(elevator, List.of(
+        getMotor(elevator, "leftMotor"),
+        getMotor(elevator, "rightMotor")));
+
+    // Manipulator
+    ManipulatorSubsystem manip = new ManipulatorSubsystem();
+    verifySubsystem(manip, List.of(getMotor(manip, "manipulatorMotor")));
+  }
+
+  private void verifySubsystem(Object subsystem, List<SparkBase> motors) {
+    // Start from a nonstandard voltage to ensure simulation updates RoboRioSim
+    RoboRioSim.setVInVoltage(7.0);
+    if (subsystem instanceof edu.wpi.first.wpilibj2.command.SubsystemBase) {
+      edu.wpi.first.wpilibj2.command.SubsystemBase s =
+          (edu.wpi.first.wpilibj2.command.SubsystemBase) subsystem;
+      // First pass uses the pre-set voltage and updates the battery model
+      s.simulationPeriodic();
+      // Second pass should now use the simulated battery voltage
+      s.simulationPeriodic();
+    }
+    double battery = RobotController.getBatteryVoltage();
+    assertTrue(battery > 0.0, "Battery voltage was not set by simulation");
+    assertNotEquals(7.0, battery, 1e-5, "Battery voltage did not change");
+    for (SparkBase motor : motors) {
+      assertEquals(battery, motor.getBusVoltage(), 1e-5);
+      motor.close();
+    }
+  }
+
+  private SparkBase getMotor(Object obj, String field) throws Exception {
+    Field f = obj.getClass().getDeclaredField(field);
+    f.setAccessible(true);
+    return (SparkBase) f.get(obj);
+  }
+
+  private List<SparkBase> collectDriveMotors(DriveSubsystem drive) throws Exception {
+    Field modulesField = DriveSubsystem.class.getDeclaredField("m_modules");
+    modulesField.setAccessible(true);
+    Object[] modules = (Object[]) modulesField.get(drive);
+    List<SparkBase> motors = new ArrayList<>();
+    Field driveField = MAXSwerveModule.class.getDeclaredField("m_drivingSpark");
+    driveField.setAccessible(true);
+    Field turnField = MAXSwerveModule.class.getDeclaredField("m_turningSpark");
+    turnField.setAccessible(true);
+    for (Object module : modules) {
+      motors.add((SparkBase) driveField.get(module));
+      motors.add((SparkBase) turnField.get(module));
+    }
+    closeIfPresent(drive, "m_gyro");
+    return motors;
+  }
+
+  private void closeIfPresent(Object obj, String field) {
+    try {
+      Field f = obj.getClass().getDeclaredField(field);
+      f.setAccessible(true);
+      Object device = f.get(obj);
+      if (device instanceof AutoCloseable) {
+        ((AutoCloseable) device).close();
+      }
+    } catch (NoSuchFieldException | IllegalAccessException ignored) {
+      // Field not present or not accessible; ignore.
+    } catch (Exception e) {
+      // Suppress close exceptions
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- use RobotController.getBatteryVoltage in all subsystem sims to prevent zero vbus errors
- add unit test verifying motor sims draw from RoboRIO battery model

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c457089f90832f99ec47d94ca86bf4