### PR TITLE
Initialize simulation battery voltage before subsystem updates

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -60,6 +60,7 @@ public class Robot extends TimedRobot {
   private FlytLogger simDash = new FlytLogger("Simulation");
   private double totalCurrentDraw;
   private double loadedBatteryVoltage;
+  private double m_simulatedBatteryVoltage;
 
   public Robot() {
     if (RobotBase.isReal()) {
@@ -111,7 +112,15 @@ public class Robot extends TimedRobot {
   }
 
   @Override
+  public void simulationInit() {
+    m_simulatedBatteryVoltage = 12.0;
+    RoboRioSim.setVInVoltage(m_simulatedBatteryVoltage);
+  }
+
+  @Override
   public void simulationPeriodic() {
+    RoboRioSim.setVInVoltage(m_simulatedBatteryVoltage);
+
     // Allow subsystems to run their individual simulation logic
     if (m_robotContainer != null) {
       m_robotContainer.simulationPeriodic();
@@ -133,16 +142,11 @@ public class Robot extends TimedRobot {
           Timer.getFPGATimestamp());
     }
 
-    totalCurrentDraw =
-        m_robotDrive.getCurrentDraw()
-            + m_elevator.getCurrentDraw()
-            + m_manipulator.getCurrentDraw()
-            + m_DiffArm.getCurrentDraw()
-            + m_climber.getCurrentDraw();
-    loadedBatteryVoltage = BatterySim.calculateDefaultBatteryLoadedVoltage(totalCurrentDraw);
-    RoboRioSim.setVInVoltage(loadedBatteryVoltage);
+    double drawnCurrent = RoboRioSim.getVInCurrent();
+    totalCurrentDraw = drawnCurrent;
+    loadedBatteryVoltage = BatterySim.calculateDefaultBatteryLoadedVoltage(drawnCurrent);
+    m_simulatedBatteryVoltage = loadedBatteryVoltage;
     simDash.update(Constants.debugMode);
-
   }
 
   /** This function is called once each time the robot enters Disabled mode. */

--- a/src/main/java/frc/robot/subsystems/ClimbSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimbSubsystem.java
@@ -23,8 +23,6 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.Servo;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
-import edu.wpi.first.wpilibj.simulation.BatterySim;
-import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -246,6 +244,9 @@ public class ClimbSubsystem extends SubsystemBase {
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && climberSim != null && armSim != null) {
             double busVoltage = RobotController.getBatteryVoltage();
+            if (busVoltage <= 0.0) {
+                return;
+            }
             double appliedVoltage = climberSim.getAppliedOutput() * busVoltage;
             boolean retracting = appliedVoltage < 0.0;
 
@@ -270,8 +271,6 @@ public class ClimbSubsystem extends SubsystemBase {
                 Units.radiansToRotations(armSim.getAngleRads() * Climber.kSimGearing));
             climberEncoderSim.setVelocity(rotorRPM);
 
-            RoboRioSim.setVInVoltage(
-                BatterySim.calculateDefaultBatteryLoadedVoltage(armSim.getCurrentDrawAmps()));
         }
     }
 }

--- a/src/main/java/frc/robot/subsystems/DifferentialSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DifferentialSubsystem.java
@@ -24,8 +24,6 @@ import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
-import edu.wpi.first.wpilibj.simulation.BatterySim;
-import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.math.util.Units;
 import frc.utils.DifferentialArmSim;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -362,6 +360,9 @@ public class DifferentialSubsystem extends SubsystemBase {
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && armSim != null && leftSim != null && rightSim != null) {
             double busVoltage = RobotController.getBatteryVoltage();
+            if (busVoltage <= 0.0) {
+                return;
+            }
 
             double leftVolts = leftSim.getAppliedOutput() * busVoltage;
             double rightVolts = rightSim.getAppliedOutput() * busVoltage;
@@ -397,9 +398,6 @@ public class DifferentialSubsystem extends SubsystemBase {
             leftEncoderSim.setVelocity(leftRPM);
             rightEncoderSim.setVelocity(rightRPM);
 
-            RoboRioSim.setVInVoltage(
-                BatterySim.calculateDefaultBatteryLoadedVoltage(
-                    armSim.getTotalCurrentAbsAmps()));
         }
     }
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -16,8 +16,6 @@ import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.simulation.SimDeviceSim;
 import edu.wpi.first.hal.SimDouble;
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.wpilibj.simulation.BatterySim;
-import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -298,6 +296,9 @@ public class DriveSubsystem extends SubsystemBase {
         }
 
         double batteryVoltage = RobotController.getBatteryVoltage();
+        if (batteryVoltage <= 0.0) {
+            return;
+        }
         SwerveModuleSim.ModuleForce[] forces = new SwerveModuleSim.ModuleForce[m_moduleSims.length];
         var speeds = swerveDriveSim.getSpeeds();
         double[] offsets = {
@@ -341,8 +342,6 @@ public class DriveSubsystem extends SubsystemBase {
         actVyPublisher.set(actual.vyMetersPerSecond);
         actOmegaPublisher.set(actual.omegaRadiansPerSecond);
 
-        RoboRioSim.setVInVoltage(
-            BatterySim.calculateDefaultBatteryLoadedVoltage(getCurrentDraw()));
     }
 
     public void setSlowSpeed() {

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -19,9 +19,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
-import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.ElevatorSim;
-import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -227,6 +225,9 @@ public class ElevatorSubsystem extends SubsystemBase {
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && leftSim != null && elevatorModel != null) {
             double busVoltage = RobotController.getBatteryVoltage();
+            if (busVoltage <= 0.0) {
+                return;
+            }
 
             elevatorModel.setInputVoltage(leftSim.getAppliedOutput() * busVoltage);
             elevatorModel.update(0.02);
@@ -243,9 +244,6 @@ public class ElevatorSubsystem extends SubsystemBase {
             leftEncoderSim.setPosition(Units.radiansToRotations(motorAngle));
             leftEncoderSim.setVelocity(rotorRPM);
 
-            RoboRioSim.setVInVoltage(
-                BatterySim.calculateDefaultBatteryLoadedVoltage(
-                    elevatorModel.getCurrentDrawAmps()));
         }
     }
 }

--- a/src/main/java/frc/robot/subsystems/ManipulatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ManipulatorSubsystem.java
@@ -21,8 +21,6 @@ import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.DCMotorSim;
-import edu.wpi.first.wpilibj.simulation.RoboRioSim;
-import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -199,6 +197,9 @@ public class ManipulatorSubsystem extends SubsystemBase {
     public void simulationPeriodic() {
         if (RobotBase.isSimulation() && manipSim != null && motorModel != null) {
             double busVoltage = RobotController.getBatteryVoltage();
+            if (busVoltage <= 0.0) {
+                return;
+            }
             motorModel.setInputVoltage(manipSim.getAppliedOutput() * busVoltage);
             motorModel.update(0.02);
 
@@ -222,9 +223,6 @@ public class ManipulatorSubsystem extends SubsystemBase {
                 coralIntakeTimer.stop();
             }
 
-            RoboRioSim.setVInVoltage(
-                BatterySim.calculateDefaultBatteryLoadedVoltage(
-                    motorModel.getCurrentDrawAmps()));
         }
     }
 

--- a/src/test/java/frc/robot/subsystems/BatterySimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/BatterySimulationTest.java
@@ -28,45 +28,44 @@ public class BatterySimulationTest {
   @Test
   public void motorsFollowRobotControllerBatteryVoltage() throws Exception {
     // Drive subsystem
+    RoboRioSim.setVInVoltage(12.0);
     DriveSubsystem drive = new DriveSubsystem();
     verifySubsystem(drive, collectDriveMotors(drive));
 
     // Climb subsystem
+    RoboRioSim.setVInVoltage(12.0);
     ClimbSubsystem climb = new ClimbSubsystem();
     verifySubsystem(climb, List.of(getMotor(climb, "leftMotor")));
     closeIfPresent(climb, "servo");
 
     // Differential arm
+    RoboRioSim.setVInVoltage(12.0);
     DifferentialSubsystem diff = new DifferentialSubsystem();
     verifySubsystem(diff, List.of(
         getMotor(diff, "leftMotor"),
         getMotor(diff, "rightMotor")));
 
     // Elevator
+    RoboRioSim.setVInVoltage(12.0);
     ElevatorSubsystem elevator = new ElevatorSubsystem();
     verifySubsystem(elevator, List.of(
         getMotor(elevator, "leftMotor"),
         getMotor(elevator, "rightMotor")));
 
     // Manipulator
+    RoboRioSim.setVInVoltage(12.0);
     ManipulatorSubsystem manip = new ManipulatorSubsystem();
     verifySubsystem(manip, List.of(getMotor(manip, "manipulatorMotor")));
   }
 
   private void verifySubsystem(Object subsystem, List<SparkBase> motors) {
-    // Start from a nonstandard voltage to ensure simulation updates RoboRioSim
-    RoboRioSim.setVInVoltage(7.0);
     if (subsystem instanceof edu.wpi.first.wpilibj2.command.SubsystemBase) {
       edu.wpi.first.wpilibj2.command.SubsystemBase s =
           (edu.wpi.first.wpilibj2.command.SubsystemBase) subsystem;
-      // First pass uses the pre-set voltage and updates the battery model
-      s.simulationPeriodic();
-      // Second pass should now use the simulated battery voltage
       s.simulationPeriodic();
     }
     double battery = RobotController.getBatteryVoltage();
     assertTrue(battery > 0.0, "Battery voltage was not set by simulation");
-    assertNotEquals(7.0, battery, 1e-5, "Battery voltage did not change");
     for (SparkBase motor : motors) {
       assertEquals(battery, motor.getBusVoltage(), 1e-5);
       motor.close();

--- a/src/test/java/frc/robot/subsystems/DriveSubsystemSimulationTest.java
+++ b/src/test/java/frc/robot/subsystems/DriveSubsystemSimulationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 
 public class DriveSubsystemSimulationTest {
   @BeforeAll
@@ -20,6 +21,7 @@ public class DriveSubsystemSimulationTest {
 
   @Test
   public void estimatorTracksGroundTruth() {
+    RoboRioSim.setVInVoltage(12.0);
     DriveSubsystem drive = new DriveSubsystem();
     PoseEstimatorSubsystem estimator = new PoseEstimatorSubsystem(
         drive::newHeading,


### PR DESCRIPTION
## Summary
- initialize a persistent simulated battery voltage in `simulationInit`
- recalc battery from total current with `RoboRioSim.getVInCurrent()` after subsystem simulations
- guard subsystem simulations against zero bus voltage and update tests for new battery model

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c48cda025c832f8d0a3560cc6737ba