### PR TITLE
Fix drive feedforward units and soften swerve constraints

### DIFF
--- a/src/main/java/frc/robot/Configs.java
+++ b/src/main/java/frc/robot/Configs.java
@@ -17,9 +17,10 @@ public final class Configs {
             double drivingFactor = ModuleConstants.kWheelDiameterMeters * Math.PI
                     / ModuleConstants.kDrivingMotorReduction;
             double turningFactor = 2 * Math.PI;
-            double drivingVelocityFeedForward = 0.13569; //1 / ModuleConstants.kDriveWheelFreeSpeedRps;//(2.2311/12.0); //0.13569; //1 / ModuleConstants.kDriveWheelFreeSpeedRps;
+            double drivingVelocityFeedForward = 1.0 / ModuleConstants.kDriveWheelFreeSpeedRps;
+            // Feedforward is expressed as percent output per meter-per-second so a
+            // setpoint equal to the wheel free speed results in full output.
             //double turnPositionFeedforward = 0.31697;
-
             drivingConfig
                     .idleMode(IdleMode.kBrake)
                     .smartCurrentLimit(50);

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -201,6 +201,8 @@ public final class Constants {
         public static final double kRobotMassKg = 50.0;
         public static final double kLinearDampingCoeff = 0.2;
         public static final double kAngularDampingCoeff = 0.05;
+        // Blend factor for softening non-holonomic constraints in simulation (1.0 = rigid)
+        public static final double kConstraintBeta = 0.9;
         public static final double kRobotMomentOfInertia =
                 kRobotMassKg * (kWheelBase * kWheelBase + kTrackWidth * kTrackWidth) / 12.0;
 

--- a/src/main/java/frc/robot/commands/Autos/DriveTestAuto.java
+++ b/src/main/java/frc/robot/commands/Autos/DriveTestAuto.java
@@ -1,6 +1,7 @@
 package frc.robot.commands.Autos;
 
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.subsystems.DriveSubsystem;
@@ -10,18 +11,33 @@ import frc.utils.PoseEstimatorSubsystem;
 public class DriveTestAuto extends SequentialCommandGroup {
   public DriveTestAuto(DriveSubsystem drive, PoseEstimatorSubsystem pose) {
     addRequirements(drive);
+    final double[] lastPrint = {0.0};
     addCommands(
         Commands.runOnce(() -> System.out.println("Starting Drive Test")),
         Commands.run(() -> {
           drive.drive(1.0, 0.0, 0.0, false);
-          ChassisSpeeds speeds = pose.getChassisSpeeds();
-          System.out.printf(
-              "vx: %.2f vy: %.2f omega: %.2f pose: %s%n",
-              speeds.vxMetersPerSecond,
-              speeds.vyMetersPerSecond,
-              speeds.omegaRadiansPerSecond,
-              pose.getCurrentPose());
-        }).withTimeout(2.0),
+          double now = Timer.getFPGATimestamp();
+          if (now - lastPrint[0] > 0.2) {
+            lastPrint[0] = now;
+            ChassisSpeeds speeds = pose.getChassisSpeeds();
+            double[] currents = drive.getModuleCurrents();
+            double[] outputs = drive.getDriveAppliedOutputs();
+            System.out.printf(
+                "vx: %.2f vy: %.2f omega: %.2f pose: %s curr: [%.1f %.1f %.1f %.1f] out: [%.2f %.2f %.2f %.2f]%n",
+                speeds.vxMetersPerSecond,
+                speeds.vyMetersPerSecond,
+                speeds.omegaRadiansPerSecond,
+                pose.getCurrentPose(),
+                currents[0],
+                currents[1],
+                currents[2],
+                currents[3],
+                outputs[0],
+                outputs[1],
+                outputs[2],
+                outputs[3]);
+          }
+        }).withTimeout(1.0),
         Commands.runOnce(() -> {
           drive.drive(0.0, 0.0, 0.0, false);
           System.out.println("Drive test complete, final pose: " + pose.getCurrentPose());

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -236,7 +236,8 @@ public class DriveSubsystem extends SubsystemBase {
                 DriveConstants.kRobotMassKg,
                 DriveConstants.kRobotMomentOfInertia,
                 DriveConstants.kLinearDampingCoeff,
-                DriveConstants.kAngularDampingCoeff);
+                DriveConstants.kAngularDampingCoeff,
+                DriveConstants.kConstraintBeta);
         } else {
             m_field = null;
             m_moduleSims = null;
@@ -287,6 +288,26 @@ public class DriveSubsystem extends SubsystemBase {
             total += module.getCurrentDraw();
         }
         return total;
+    }
+
+    /** Returns the applied output for each drive motor. */
+    public double[] getDriveAppliedOutputs() {
+        return new double[] {
+            m_frontLeft.getDriveAppliedOutput(),
+            m_frontRight.getDriveAppliedOutput(),
+            m_rearLeft.getDriveAppliedOutput(),
+            m_rearRight.getDriveAppliedOutput()
+        };
+    }
+
+    /** Returns the current draw of each module. */
+    public double[] getModuleCurrents() {
+        return new double[] {
+            m_frontLeft.getCurrentDraw(),
+            m_frontRight.getCurrentDraw(),
+            m_rearLeft.getCurrentDraw(),
+            m_rearRight.getCurrentDraw()
+        };
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
@@ -4,7 +4,6 @@
 
 package frc.robot.subsystems;
 
-import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
@@ -23,7 +22,6 @@ import com.revrobotics.spark.SparkBase.PersistMode;
 import com.revrobotics.spark.SparkBase.ResetMode;
 import com.revrobotics.spark.SparkLowLevel.MotorType;
 import com.revrobotics.spark.config.SparkBaseConfig.IdleMode;
-
 
 import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.RelativeEncoder;
@@ -45,7 +43,6 @@ public class MAXSwerveModule {
     private double m_chassisAngularOffset = 0;
     private SwerveModuleState m_desiredState = new SwerveModuleState(0.0, new Rotation2d());
 
-    private SimpleMotorFeedforward feedforward = new SimpleMotorFeedforward(0.13569, 2.2311);
 
     private FlytLogger test = new FlytLogger("Swerve");
 
@@ -183,6 +180,15 @@ public class MAXSwerveModule {
      */
     public double getCurrentDraw() {
         return m_drivingSpark.getOutputCurrent() + m_turningSpark.getOutputCurrent();
+    }
+
+    /**
+     * Returns the drive motor applied output as a fraction of the supply voltage.
+     *
+     * @return Applied output in the range [-1, 1].
+     */
+    public double getDriveAppliedOutput() {
+        return m_drivingSpark.getAppliedOutput();
     }
 
     public void runDriveCharacterization(double output) {


### PR DESCRIPTION
## Summary
- correct Spark velocity feedforward to 1 / wheel free speed so units are percent output per m/s
- remove unused SimpleMotorFeedforward from MAXSwerveModule
- log drive currents and applied outputs during DriveTestAuto for easier debugging
- expose unconstrained chassis speeds and projection acceleration in SwerveDriveSim and add tests ensuring the constraint preserves forward velocity and has negligible effect even with misaligned modules
- allow softening SwerveDriveSim constraints via a beta blend factor and document its usage
- remove obsolete SwerveDriveSimulatorPlan.md and add a unit test validating beta blending between constrained and unconstrained motion

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a86d7538832fa7bccb353598ebc9