### PR TITLE
Fix swerve drive velocity conversion

### DIFF
--- a/src/main/java/frc/robot/Configs.java
+++ b/src/main/java/frc/robot/Configs.java
@@ -15,9 +15,10 @@ public final class Configs {
         static {
             // Use module constants to calculate conversion factors and feed forward gain.
             double turningFactor = 2 * Math.PI;
-            double drivingVelocityFeedForward = 1.0 / ModuleConstants.kDriveWheelFreeSpeedMetersPerSecond;
-            // Feedforward is expressed as percent output per meter-per-second so a
-            // setpoint equal to the wheel free speed results in full output.
+            // SPARK velocity feedforward expects a value in percent output per RPM.
+            // Use the motor's free speed in RPM so that a setpoint equal to the
+            // free speed results in full output from the controller.
+            double drivingVelocityFeedForward = 1.0 / Constants.NeoMotorConstants.kFreeSpeedRpm;
             drivingConfig
                     .idleMode(IdleMode.kBrake)
                     .smartCurrentLimit(50);

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -179,11 +179,6 @@ public final class Constants {
     }
 
     public static final class DriveConstants {
-        // Driving Parameters - Note that these are not the maximum capable speeds of
-        // the robot, rather the allowed maximum speeds
-        public static final double kMaxSpeedMetersPerSecond = 5.74;
-        public static final double kMaxAngularSpeed = 2 * Math.PI; // radians per second
-
         // Chassis configuration
         public static final double kTrackWidth = Units.inchesToMeters(26.5);
         // Distance between centers of right and left wheels on robot
@@ -196,6 +191,14 @@ public final class Constants {
                 new Translation2d(-kWheelBase / 2, -kTrackWidth / 2)
         };
         public static final SwerveDriveKinematics kDriveKinematics = new SwerveDriveKinematics(kModuleTranslations);
+
+        // Driving Parameters - the following limits are derived from the physical
+        // characteristics of the module and robot geometry.
+        public static final double kMaxSpeedMetersPerSecond =
+                ModuleConstants.kDriveWheelFreeSpeedMetersPerSecond;
+        public static final double kMaxAngularSpeed =
+                kMaxSpeedMetersPerSecond /
+                        Math.hypot(kWheelBase / 2.0, kTrackWidth / 2.0); // radians per second
 
         // Physical properties used for simulation
         public static final double kRobotMassKg = 50.0;
@@ -245,6 +248,8 @@ public final class Constants {
         // Encoder conversion factors: raw motor rotations -> meters
         public static final double kDriveEncoderPositionFactor =
                 kWheelCircumferenceMeters / kDrivingMotorReduction; // meters per motor rotation
+        // The Spark Flex reports velocity in RPM, so convert motor RPM to linear wheel
+        // speed using 60 seconds per minute.
         public static final double kDriveEncoderVelocityFactor =
                 kDriveEncoderPositionFactor / 60.0; // meters per second per RPM
 

--- a/src/test/java/frc/robot/ConstantsUnitTest.java
+++ b/src/test/java/frc/robot/ConstantsUnitTest.java
@@ -6,11 +6,42 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests that sanity check drive module unit conversions. */
 public class ConstantsUnitTest {
+
+  @Test
+  void driveEncoderPositionFactorMatchesGeometry() {
+    double expected =
+        Constants.ModuleConstants.kWheelCircumferenceMeters
+            / Constants.ModuleConstants.kDrivingMotorReduction;
+    assertEquals(expected, Constants.ModuleConstants.kDriveEncoderPositionFactor, 1e-9);
+  }
+
+  @Test
+  void driveEncoderVelocityFactorConvertsRpmToMetersPerSecond() {
+    double expected = Constants.ModuleConstants.kDriveEncoderPositionFactor / 60.0;
+    assertEquals(expected, Constants.ModuleConstants.kDriveEncoderVelocityFactor, 1e-9);
+  }
+
   @Test
   void driveEncoderConversionMatchesFreeSpeed() {
     double wheelSpeed =
-        Constants.NeoMotorConstants.kFreeSpeedRpm * Constants.ModuleConstants.kDriveEncoderVelocityFactor;
+        Constants.NeoMotorConstants.kFreeSpeedRpm
+            * Constants.ModuleConstants.kDriveEncoderVelocityFactor;
     assertEquals(Constants.ModuleConstants.kDriveWheelFreeSpeedMetersPerSecond, wheelSpeed, 1e-6);
+  }
+
+  @Test
+  void driveConstantsDerivedFromModuleConstants() {
+    assertEquals(
+        Constants.ModuleConstants.kDriveWheelFreeSpeedMetersPerSecond,
+        Constants.DriveConstants.kMaxSpeedMetersPerSecond,
+        1e-9);
+    double expectedMaxAngular =
+        Constants.DriveConstants.kMaxSpeedMetersPerSecond
+            /
+            Math.hypot(
+                Constants.DriveConstants.kWheelBase / 2.0,
+                Constants.DriveConstants.kTrackWidth / 2.0);
+    assertEquals(expectedMaxAngular, Constants.DriveConstants.kMaxAngularSpeed, 1e-9);
   }
 }
 


### PR DESCRIPTION
## Summary
- derive drive speed and angular limits from module geometry
- convert drive encoder velocity from RPM to linear wheel speed
- add unit tests validating drive conversion factors and limits

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d4efb454832f8d5d4b73f84aaa8b