### PR TITLE
Auto-switch scoring nodes based on LaserCan range

### DIFF
--- a/src/main/java/frc/robot/commands/ElevatorManipulator/InterpolatedScoreCommand.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/InterpolatedScoreCommand.java
@@ -1,0 +1,114 @@
+package frc.robot.commands.ElevatorManipulator;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.DifferentialSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ManipulatorStateMachine;
+
+/**
+ * Base command for scoring positions that rely on the LaserCan distance sensor
+ * to interpolate differential arm setpoints. Each concrete implementation
+ * supplies the desired elevator height, default arm positions, and the
+ * interpolation callbacks for its scoring level.
+ */
+public abstract class InterpolatedScoreCommand extends Command {
+
+    private final ManipulatorStateMachine manipulatorStateMachine;
+    private final DifferentialSubsystem differentialSubsystem;
+    private final ElevatorSubsystem elevatorSubsystem;
+    private final double elevatorSetpoint;
+    private final double defaultExtension;
+    private final double defaultRotation;
+    private final DoubleSupplier extensionInterpolation;
+    private final DoubleSupplier rotationInterpolation;
+
+    private boolean atPosition = false;
+    private boolean usingInterpolation = false;
+
+    protected InterpolatedScoreCommand(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem,
+            double elevatorSetpoint,
+            double defaultExtension,
+            double defaultRotation,
+            DoubleSupplier extensionInterpolation,
+            DoubleSupplier rotationInterpolation) {
+        this.manipulatorStateMachine = manipulatorStateMachine;
+        this.differentialSubsystem = differentialSubsystem;
+        this.elevatorSubsystem = elevatorSubsystem;
+        this.elevatorSetpoint = elevatorSetpoint;
+        this.defaultExtension = defaultExtension;
+        this.defaultRotation = defaultRotation;
+        this.extensionInterpolation = extensionInterpolation;
+        this.rotationInterpolation = rotationInterpolation;
+
+        addRequirements(differentialSubsystem, elevatorSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        atPosition = false;
+        usingInterpolation = false;
+        manipulatorStateMachine.atGoalState(false);
+
+        elevatorSubsystem.setElevatorSetpoint(elevatorSetpoint);
+        differentialSubsystem.setExtensionSetpoint(defaultExtension);
+        differentialSubsystem.setRotationSetpoint(defaultRotation);
+    }
+
+    @Override
+    public void execute() {
+        double extensionTarget = defaultExtension;
+        double rotationTarget = defaultRotation;
+
+        if (differentialSubsystem.hasLaserCanDistance()) {
+            extensionTarget = extensionInterpolation.getAsDouble();
+            rotationTarget = rotationInterpolation.getAsDouble();
+            usingInterpolation = true;
+        } else {
+            usingInterpolation = false;
+        }
+
+        differentialSubsystem.setExtensionSetpoint(extensionTarget);
+        differentialSubsystem.setRotationSetpoint(rotationTarget);
+
+        if (differentialSubsystem.atRotationSetpoint()
+                && differentialSubsystem.atExtenstionSetpoint()
+                && elevatorSubsystem.atPosition()) {
+            atPosition = true;
+            manipulatorStateMachine.atGoalState(true);
+        }
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        if (!differentialSubsystem.hasLaserCanDistance()) {
+            differentialSubsystem.setExtensionSetpoint(defaultExtension);
+            differentialSubsystem.setRotationSetpoint(defaultRotation);
+        }
+        manipulatorStateMachine.atGoalState(false);
+    }
+
+    @Override
+    public boolean isFinished() {
+        if (!differentialSubsystem.hasLaserCanDistance() && manipulatorStateMachine.getHasCoral()) {
+            return true;
+        }
+        return atPosition && !manipulatorStateMachine.getHasCoral();
+    }
+
+    /**
+     * Indicates whether the command is currently using interpolated setpoints or
+     * the static fallbacks.
+     *
+     * @return {@code true} when a valid LaserCan reading is being used for
+     *         interpolation.
+     */
+    protected boolean isUsingInterpolation() {
+        return usingInterpolation;
+    }
+}
+

--- a/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL2.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL2.java
@@ -1,5 +1,65 @@
 package frc.robot.commands.ElevatorManipulator;
 
-public class ScoreL2 {
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.DifferentialSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ManipulatorStateMachine;
 
+/** Score command for the L2 reef level using preset arm setpoints. */
+public class ScoreL2 extends Command {
+
+    private static final double ELEVATOR_SETPOINT = 0.74;
+    private static final double EXTENSION_SETPOINT = 170;
+    private static final double ROTATION_SETPOINT = 230;
+
+    private final ManipulatorStateMachine manipulatorStateMachine;
+    private final DifferentialSubsystem differentialSubsystem;
+    private final ElevatorSubsystem elevatorSubsystem;
+
+    private boolean atPosition = false;
+
+    public ScoreL2(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem) {
+        this.manipulatorStateMachine = manipulatorStateMachine;
+        this.differentialSubsystem = differentialSubsystem;
+        this.elevatorSubsystem = elevatorSubsystem;
+
+        addRequirements(differentialSubsystem, elevatorSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        atPosition = false;
+        manipulatorStateMachine.atGoalState(false);
+
+        elevatorSubsystem.setElevatorSetpoint(ELEVATOR_SETPOINT);
+        differentialSubsystem.setExtensionSetpoint(EXTENSION_SETPOINT);
+        differentialSubsystem.setRotationSetpoint(ROTATION_SETPOINT);
+    }
+
+    @Override
+    public void execute() {
+        if (differentialSubsystem.atRotationSetpoint()
+                && differentialSubsystem.atExtenstionSetpoint()
+                && elevatorSubsystem.atPosition()) {
+            atPosition = true;
+            manipulatorStateMachine.atGoalState(true);
+        }
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        manipulatorStateMachine.atGoalState(false);
+    }
+
+    @Override
+    public boolean isFinished() {
+        if (differentialSubsystem.hasLaserCanDistance() && manipulatorStateMachine.getHasCoral()) {
+            return true;
+        }
+        return atPosition && !manipulatorStateMachine.getHasCoral();
+    }
 }
+

--- a/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL2Interpolated.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL2Interpolated.java
@@ -1,0 +1,28 @@
+package frc.robot.commands.ElevatorManipulator;
+
+import frc.robot.subsystems.DifferentialSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ManipulatorStateMachine;
+
+/** Score command for the L2 reef level using interpolated arm setpoints. */
+public class ScoreL2Interpolated extends InterpolatedScoreCommand {
+
+    private static final double ELEVATOR_SETPOINT = 0.74;
+    private static final double DEFAULT_EXTENSION = 170;
+    private static final double DEFAULT_ROTATION = 230;
+
+    public ScoreL2Interpolated(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem) {
+        super(
+                manipulatorStateMachine,
+                differentialSubsystem,
+                elevatorSubsystem,
+                ELEVATOR_SETPOINT,
+                DEFAULT_EXTENSION,
+                DEFAULT_ROTATION,
+                differentialSubsystem::l2_3ExtensionInterpolate,
+                differentialSubsystem::l2_3RotationInterpolate);
+    }
+}

--- a/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL3.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL3.java
@@ -1,5 +1,65 @@
 package frc.robot.commands.ElevatorManipulator;
 
-public class ScoreL3 {
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.DifferentialSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ManipulatorStateMachine;
 
+/** Score command for the L3 reef level using preset arm setpoints. */
+public class ScoreL3 extends Command {
+
+    private static final double ELEVATOR_SETPOINT = 1.14;
+    private static final double EXTENSION_SETPOINT = 170;
+    private static final double ROTATION_SETPOINT = 230;
+
+    private final ManipulatorStateMachine manipulatorStateMachine;
+    private final DifferentialSubsystem differentialSubsystem;
+    private final ElevatorSubsystem elevatorSubsystem;
+
+    private boolean atPosition = false;
+
+    public ScoreL3(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem) {
+        this.manipulatorStateMachine = manipulatorStateMachine;
+        this.differentialSubsystem = differentialSubsystem;
+        this.elevatorSubsystem = elevatorSubsystem;
+
+        addRequirements(differentialSubsystem, elevatorSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        atPosition = false;
+        manipulatorStateMachine.atGoalState(false);
+
+        elevatorSubsystem.setElevatorSetpoint(ELEVATOR_SETPOINT);
+        differentialSubsystem.setExtensionSetpoint(EXTENSION_SETPOINT);
+        differentialSubsystem.setRotationSetpoint(ROTATION_SETPOINT);
+    }
+
+    @Override
+    public void execute() {
+        if (differentialSubsystem.atRotationSetpoint()
+                && differentialSubsystem.atExtenstionSetpoint()
+                && elevatorSubsystem.atPosition()) {
+            atPosition = true;
+            manipulatorStateMachine.atGoalState(true);
+        }
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        manipulatorStateMachine.atGoalState(false);
+    }
+
+    @Override
+    public boolean isFinished() {
+        if (differentialSubsystem.hasLaserCanDistance() && manipulatorStateMachine.getHasCoral()) {
+            return true;
+        }
+        return atPosition && !manipulatorStateMachine.getHasCoral();
+    }
 }
+

--- a/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL3Interpolated.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL3Interpolated.java
@@ -1,0 +1,28 @@
+package frc.robot.commands.ElevatorManipulator;
+
+import frc.robot.subsystems.DifferentialSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ManipulatorStateMachine;
+
+/** Score command for the L3 reef level using interpolated arm setpoints. */
+public class ScoreL3Interpolated extends InterpolatedScoreCommand {
+
+    private static final double ELEVATOR_SETPOINT = 1.14;
+    private static final double DEFAULT_EXTENSION = 170;
+    private static final double DEFAULT_ROTATION = 230;
+
+    public ScoreL3Interpolated(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem) {
+        super(
+                manipulatorStateMachine,
+                differentialSubsystem,
+                elevatorSubsystem,
+                ELEVATOR_SETPOINT,
+                DEFAULT_EXTENSION,
+                DEFAULT_ROTATION,
+                differentialSubsystem::l2_3ExtensionInterpolate,
+                differentialSubsystem::l2_3RotationInterpolate);
+    }
+}

--- a/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL4.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL4.java
@@ -1,85 +1,65 @@
 package frc.robot.commands.ElevatorManipulator;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.Constants;
 import frc.robot.subsystems.DifferentialSubsystem;
 import frc.robot.subsystems.ElevatorSubsystem;
 import frc.robot.subsystems.ManipulatorStateMachine;
 
+/** Score command for the L4 reef level using preset arm setpoints. */
 public class ScoreL4 extends Command {
 
-    private ManipulatorStateMachine manipulatorSm;
-    private DifferentialSubsystem diffArm;
-    private ElevatorSubsystem elevator;
-    //private ManipulatorSubsystem manipulator;
-    //private final Timer stepTimer = new Timer();
-    //private int step = 0;
+    private static final double ELEVATOR_SETPOINT = 1.72;
+    private static final double EXTENSION_SETPOINT = 140;
+    private static final double ROTATION_SETPOINT = 235;
+
+    private final ManipulatorStateMachine manipulatorStateMachine;
+    private final DifferentialSubsystem differentialSubsystem;
+    private final ElevatorSubsystem elevatorSubsystem;
+
     private boolean atPosition = false;
-    private boolean isInterpolated = false;
-    private boolean isCoralScored = false;
 
-    private double elevatorPos = 1.72;
-    private double diffExt = 140;
-    private double diffRot = 235;
-    private double diffExt1 = 220;
+    public ScoreL4(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem) {
+        this.manipulatorStateMachine = manipulatorStateMachine;
+        this.differentialSubsystem = differentialSubsystem;
+        this.elevatorSubsystem = elevatorSubsystem;
 
-    public ScoreL4(ManipulatorStateMachine m_state, DifferentialSubsystem m_diff, ElevatorSubsystem m_elevator){
-
-        manipulatorSm = m_state;
-        diffArm = m_diff;
-        elevator = m_elevator;
-        //manipulator = m_manipulator;
-
-        addRequirements(m_diff, elevator);
+        addRequirements(differentialSubsystem, elevatorSubsystem);
     }
 
     @Override
     public void initialize() {
+        atPosition = false;
+        manipulatorStateMachine.atGoalState(false);
 
-        diffArm.setExtensionSetpoint(diffExt);
-        elevator.setElevatorSetpoint(elevatorPos);
-        diffArm.setRotationSetpoint(diffRot);
+        elevatorSubsystem.setElevatorSetpoint(ELEVATOR_SETPOINT);
+        differentialSubsystem.setExtensionSetpoint(EXTENSION_SETPOINT);
+        differentialSubsystem.setRotationSetpoint(ROTATION_SETPOINT);
     }
 
     @Override
-    public void execute(){
-
-        //place where interpolation code would be imported
-        //interpolation();
-        //this commadn only ends if robot interpolated and scored the coral
-        if(diffArm.atRotationSetpoint() && diffArm.atExtenstionSetpoint() && elevator.atPosition()){
+    public void execute() {
+        if (differentialSubsystem.atRotationSetpoint()
+                && differentialSubsystem.atExtenstionSetpoint()
+                && elevatorSubsystem.atPosition()) {
             atPosition = true;
-            manipulatorSm.atGoalState(true);
-        }
-            
-        
-
-        //safety code if it takes too long extend out out
-    }
-
-    private void interpolation(){
-
-        /** Diff Arm Interpolation */
-        if (diffArm.hasLaserCanDistance()) {
-                diffArm.setExtensionSetpoint(diffArm.l4ExtensionInterpolate());
-                diffArm.setRotationSetpoint(diffArm.l4RotationInterpolate());
+            manipulatorStateMachine.atGoalState(true);
         }
     }
 
-
-    // Called once the command ends or is interrupted.
     @Override
     public void end(boolean interrupted) {
-        manipulatorSm.atGoalState(false);
-        
+        manipulatorStateMachine.atGoalState(false);
     }
 
-
-    // Returns true when the command should end.
     @Override
     public boolean isFinished() {
-        return atPosition && !manipulatorSm.getHasCoral();
+        if (differentialSubsystem.hasLaserCanDistance() && manipulatorStateMachine.getHasCoral()) {
+            return true;
+        }
+        return atPosition && !manipulatorStateMachine.getHasCoral();
     }
-
 }
 

--- a/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL4Interpolated.java
+++ b/src/main/java/frc/robot/commands/ElevatorManipulator/ScoreL4Interpolated.java
@@ -1,0 +1,28 @@
+package frc.robot.commands.ElevatorManipulator;
+
+import frc.robot.subsystems.DifferentialSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
+import frc.robot.subsystems.ManipulatorStateMachine;
+
+/** Score command for the L4 reef level using interpolated arm setpoints. */
+public class ScoreL4Interpolated extends InterpolatedScoreCommand {
+
+    private static final double ELEVATOR_SETPOINT = 1.72;
+    private static final double DEFAULT_EXTENSION = 140;
+    private static final double DEFAULT_ROTATION = 235;
+
+    public ScoreL4Interpolated(
+            ManipulatorStateMachine manipulatorStateMachine,
+            DifferentialSubsystem differentialSubsystem,
+            ElevatorSubsystem elevatorSubsystem) {
+        super(
+                manipulatorStateMachine,
+                differentialSubsystem,
+                elevatorSubsystem,
+                ELEVATOR_SETPOINT,
+                DEFAULT_EXTENSION,
+                DEFAULT_ROTATION,
+                differentialSubsystem::l4ExtensionInterpolate,
+                differentialSubsystem::l4RotationInterpolate);
+    }
+}

--- a/src/main/java/frc/robot/commands/GraphCommand.java
+++ b/src/main/java/frc/robot/commands/GraphCommand.java
@@ -155,6 +155,10 @@ public class GraphCommand extends Command {
         return m_currentNode;
     }
 
+    public GraphCommandNode getTargetNode() {
+        return m_targetNode;
+    }
+
     public void setTargetNode(GraphCommandNode node) {
         // if the graph isn't transitioning set the next node and move on
         if (!m_isTransitioning) {

--- a/src/main/java/frc/robot/subsystems/ManipulatorStateMachine.java
+++ b/src/main/java/frc/robot/subsystems/ManipulatorStateMachine.java
@@ -15,7 +15,12 @@ import frc.robot.commands.ElevatorManipulator.IntakeCoral;
 import frc.robot.commands.ElevatorManipulator.L4Prep;
 import frc.robot.commands.ElevatorManipulator.PrepCoralIntake;
 import frc.robot.commands.ElevatorManipulator.SafeTravelSequential;
+import frc.robot.commands.ElevatorManipulator.ScoreL2;
+import frc.robot.commands.ElevatorManipulator.ScoreL2Interpolated;
+import frc.robot.commands.ElevatorManipulator.ScoreL3;
+import frc.robot.commands.ElevatorManipulator.ScoreL3Interpolated;
 import frc.robot.commands.ElevatorManipulator.ScoreL4;
+import frc.robot.commands.ElevatorManipulator.ScoreL4Interpolated;
 import frc.robot.commands.EndEffector.ManipulatorIntakeCoral;
 import frc.robot.commands.EndEffector.ScoreCoral;
 import frc.robot.subsystems.DriveStateMachine.DriveState;
@@ -67,8 +72,11 @@ public class ManipulatorStateMachine extends SubsystemBase {
     GraphCommandNode l4PrepNode;
     GraphCommandNode scoreL1Node;
     GraphCommandNode scoreL2Node;
+    GraphCommandNode scoreL2InterpolatedNode;
     GraphCommandNode scoreL3Node;
+    GraphCommandNode scoreL3InterpolatedNode;
     GraphCommandNode scoreL4Node;
+    GraphCommandNode scoreL4InterpolatedNode;
     GraphCommandNode l1PostScoreNode;
     GraphCommandNode l2PostScoreNode;
     GraphCommandNode l3PostScoreNode;
@@ -147,13 +155,13 @@ public class ManipulatorStateMachine extends SubsystemBase {
                 new PrintCommand(""));
 
             l2PrepNode = m_graphCommand.new GraphCommandNode(
-                "L2Prep", 
+                "L2Prep",
                 new PrintCommand(""),
                 new PrintCommand(""),
                 new PrintCommand(""));
 
             l3PrepNode = m_graphCommand.new GraphCommandNode(
-                "L3Prep", 
+                "L3Prep",
                 new PrintCommand(""),
                 new PrintCommand(""),
                 new PrintCommand(""));
@@ -171,21 +179,39 @@ public class ManipulatorStateMachine extends SubsystemBase {
                 new PrintCommand(""));
 
             scoreL2Node = m_graphCommand.new GraphCommandNode(
-                "ScoreL2", 
-                new PrintCommand(""),
-                new PrintCommand(""),
+                "ScoreL2",
+                new ScoreL2(this, m_diff, m_elevator),
+                new ScoreCoral(this, m_manipulator),
+                new PrintCommand(""));
+
+            scoreL2InterpolatedNode = m_graphCommand.new GraphCommandNode(
+                "ScoreL2Interpolated",
+                new ScoreL2Interpolated(this, m_diff, m_elevator),
+                new ScoreCoral(this, m_manipulator),
                 new PrintCommand(""));
 
             scoreL3Node = m_graphCommand.new GraphCommandNode(
-                "ScoreL3", 
-                new PrintCommand(""),
-                new PrintCommand(""),
+                "ScoreL3",
+                new ScoreL3(this, m_diff, m_elevator),
+                new ScoreCoral(this, m_manipulator),
+                new PrintCommand(""));
+
+            scoreL3InterpolatedNode = m_graphCommand.new GraphCommandNode(
+                "ScoreL3Interpolated",
+                new ScoreL3Interpolated(this, m_diff, m_elevator),
+                new ScoreCoral(this, m_manipulator),
                 new PrintCommand(""));
 
             scoreL4Node = m_graphCommand.new GraphCommandNode(
-                "ScoreL4", 
+                "ScoreL4",
                 new ScoreL4(this, m_diff, m_elevator),
                 new ScoreCoral(this,m_manipulator),
+                new PrintCommand(""));
+
+            scoreL4InterpolatedNode = m_graphCommand.new GraphCommandNode(
+                "ScoreL4Interpolated",
+                new ScoreL4Interpolated(this, m_diff, m_elevator),
+                new ScoreCoral(this, m_manipulator),
                 new PrintCommand(""));
 
             l1PostScoreNode = m_graphCommand.new GraphCommandNode(
@@ -298,6 +324,9 @@ public class ManipulatorStateMachine extends SubsystemBase {
         l2PrepNode.AddNode(scoreL2Node, 1.0); //l2 prep to score l2
         l3PrepNode.AddNode(scoreL3Node, 1.0); //l3 prep to score l3
         l4PrepNode.AddNode(scoreL4Node, 1.0); //l4 prep to score l4
+        scoreL2Node.AddNode(scoreL2InterpolatedNode, 1.0); //score l2 to interpolated score l2
+        scoreL3Node.AddNode(scoreL3InterpolatedNode, 1.0); //score l3 to interpolated score l3
+        scoreL4Node.AddNode(scoreL4InterpolatedNode, 1.0); //score l4 to interpolated score l4
         //scoreL1Node.AddNode(l1PrepNode, 1.0); //score l1 to l1 prep
         //scoreL2Node.AddNode(l2PrepNode, 1.0); //score l2 to l2 prep
         //scoreL3Node.AddNode(l3PrepNode, 1.0); //score l3 to l3 prep
@@ -450,9 +479,9 @@ public class ManipulatorStateMachine extends SubsystemBase {
         if(currentNode == safeCoralTravelNode) return ElevatorManipulatorState.SAFE_CORAL_TRAVEL;
         if(currentNode == intakeCoralNode) return ElevatorManipulatorState.INTAKE_CORAL;
         if(currentNode == l1PrepNode || currentNode == scoreL1Node || currentNode == l1PostScoreNode) return ElevatorManipulatorState.L1;
-        if(currentNode == l2PrepNode || currentNode == scoreL2Node || currentNode == l2PostScoreNode) return ElevatorManipulatorState.L2;
-        if(currentNode == l3PrepNode || currentNode == scoreL3Node || currentNode == l3PostScoreNode) return ElevatorManipulatorState.L3;
-        if(currentNode == l4PrepNode || currentNode == scoreL4Node || currentNode == l4PostScoreNode) return ElevatorManipulatorState.L4;
+        if(currentNode == l2PrepNode || currentNode == scoreL2Node || currentNode == scoreL2InterpolatedNode || currentNode == l2PostScoreNode) return ElevatorManipulatorState.L2;
+        if(currentNode == l3PrepNode || currentNode == scoreL3Node || currentNode == scoreL3InterpolatedNode || currentNode == l3PostScoreNode) return ElevatorManipulatorState.L3;
+        if(currentNode == l4PrepNode || currentNode == scoreL4Node || currentNode == scoreL4InterpolatedNode || currentNode == l4PostScoreNode) return ElevatorManipulatorState.L4;
         if(currentNode == prepAlgaeL2Node) return ElevatorManipulatorState.ALGAE_L2;
         if(currentNode == prepAlgaeL3Node) return ElevatorManipulatorState.ALGAE_L3;
         if(currentNode == scoreProssesorNode) return ElevatorManipulatorState.PROCESSOR;
@@ -475,7 +504,8 @@ public class ManipulatorStateMachine extends SubsystemBase {
         dashboard.putBoolean("At Final State", atGoalState());
         dashboard.putString("Current GraphState State", getGraphState().toString());
         dashboard.putBoolean("At state", !isTransitioning());
-        
+
+        updateInterpolatedScoring();
     }
 
 
@@ -485,5 +515,36 @@ public class ManipulatorStateMachine extends SubsystemBase {
     private void updateStateTracking() {
 
     }
-    
+
+    private void updateInterpolatedScoring() {
+        GraphCommandNode targetNode = m_graphCommand.getTargetNode();
+        if (targetNode == null) {
+            return;
+        }
+
+        boolean hasLaserDistance = m_diff.hasLaserCanDistance();
+
+        handleInterpolatedTarget(scoreL2Node, scoreL2InterpolatedNode, targetNode, hasLaserDistance);
+        handleInterpolatedTarget(scoreL3Node, scoreL3InterpolatedNode, targetNode, hasLaserDistance);
+        handleInterpolatedTarget(scoreL4Node, scoreL4InterpolatedNode, targetNode, hasLaserDistance);
+    }
+
+    private void handleInterpolatedTarget(
+            GraphCommandNode baseNode,
+            GraphCommandNode interpolatedNode,
+            GraphCommandNode targetNode,
+            boolean hasLaserDistance) {
+
+        if (targetNode == baseNode) {
+            if (hasLaserDistance) {
+                m_graphCommand.setTargetNode(interpolatedNode);
+            }
+            return;
+        }
+
+        if (targetNode == interpolatedNode && !hasLaserDistance) {
+            m_graphCommand.setTargetNode(baseNode);
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- expose GraphCommand#getTargetNode so the manipulator can read the active goal
- make the non-interpolated L2/L3/L4 score commands exit once a valid LaserCan reading is available
- reset interpolated score commands when the LaserCan drops out and drive the state machine between interpolated and preset nodes based on sensor range

## Testing
- bash gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68c8cadc33a4832f9e6a88b7bfdc2dcb