### PR TITLE
Make DriveTestAuto translation scalar configurable

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -296,6 +296,9 @@ public final class Constants {
   }
 
   public static final class AutoConstants {
+    /** Default translation scalar for DriveTestAuto (1.0 = full speed). */
+    public static final double kDriveTestDefaultTranslationScalar = 0.1;
+
     public static final double kMaxSpeedMetersPerSecond = 3;
     public static final double kMaxAccelerationMetersPerSecondSquared = 3;
     public static final double kMaxAngularSpeedRadiansPerSecond = Math.PI;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,6 +4,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
@@ -91,7 +92,19 @@ public class RobotContainer {
     m_ledUtility.addStrip("TopRight", 134, 143);
     m_ledUtility.setDefault();
 
-    auto_chooser.setDefaultOption("None", Commands.none());
+    if (RobotBase.isSimulation()) {
+      auto_chooser.setDefaultOption(
+          "Drive Test (Full Speed)",
+          new DriveTestAuto(
+              m_robotDrive, m_poseEstimator, DriveTestAuto.FULL_SPEED_TRANSLATION_SCALAR));
+      auto_chooser.addOption("None", Commands.none());
+    } else {
+      auto_chooser.setDefaultOption("None", Commands.none());
+      auto_chooser.addOption(
+          "Drive Test (Full Speed)",
+          new DriveTestAuto(
+              m_robotDrive, m_poseEstimator, DriveTestAuto.FULL_SPEED_TRANSLATION_SCALAR));
+    }
     // Add autonomous options
     auto_chooser.addOption("Drivetrain SysID", new DrivetrainSysId(m_robotDrive));
     auto_chooser.addOption("Drive Test", new DriveTestAuto(m_robotDrive, m_poseEstimator));
@@ -121,8 +134,6 @@ public class RobotContainer {
     JoystickButton rightStick = new JoystickButton(m_driverController, Button.kRightStick.value);
     Trigger rightTrigger = new Trigger(() -> m_driverController.getRightTriggerAxis() > 0.5);
     Trigger leftTrigger = new Trigger(() -> m_driverController.getLeftTriggerAxis() > 0.5);
-    POVButton dpadUp = new POVButton(m_driverController, 0);
-    POVButton dpadDown = new POVButton(m_driverController, 180);
     POVButton dpadLeft = new POVButton(m_driverController, 270);
     POVButton dpadRight = new POVButton(m_driverController, 90);
 

--- a/src/main/java/frc/robot/commands/Autos/DriveTestAuto.java
+++ b/src/main/java/frc/robot/commands/Autos/DriveTestAuto.java
@@ -6,20 +6,36 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.Constants.AutoConstants;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.utils.PoseEstimatorSubsystem;
 
 /** Auto to drive forward while printing chassis speeds and pose. */
 public class DriveTestAuto extends SequentialCommandGroup {
+  public static final double FULL_SPEED_TRANSLATION_SCALAR = 1.0;
+
+  private final double translationScalar;
+
   public DriveTestAuto(DriveSubsystem drive, PoseEstimatorSubsystem pose) {
+    this(drive, pose, AutoConstants.kDriveTestDefaultTranslationScalar);
+  }
+
+  public DriveTestAuto(
+      DriveSubsystem drive, PoseEstimatorSubsystem pose, double translationScalar) {
     addRequirements(drive);
+    this.translationScalar = translationScalar;
     final double[] lastPrint = {0.0};
     addCommands(
-        Commands.runOnce(() -> System.out.println("Starting Drive Test")),
+        Commands.runOnce(
+            () ->
+                System.out.printf(
+                    "Starting Drive Test with translation scalar %.2f (default %.2f, 1.0 = full speed)%n",
+                    this.translationScalar, AutoConstants.kDriveTestDefaultTranslationScalar)),
         Commands.run(
                 () -> {
-                  // Drive at a reduced speed to keep the test manageable
-                  drive.drive(0.1, 0.0, 0.0, false);
+                  // Drive using the requested scalar (defaults to 0.1 for manageable indoor
+                  // testing).
+                  drive.drive(this.translationScalar, 0.0, 0.0, false);
                   double now = Timer.getFPGATimestamp();
                   if (now - lastPrint[0] > 0.2) {
                     lastPrint[0] = now;


### PR DESCRIPTION
## Summary
- allow `DriveTestAuto` to take a caller-provided translation scalar while logging the default vs. full-speed setting
- surface a full-speed "Drive Test" autonomous option for easy selection during simulation runs
- drop unused D-pad POV button declarations that static analysis flagged after enabling SpotBugs/PMD

## Testing
- `./gradlew spotlessApply --console=plain`
- `./gradlew build --console=plain`
- `./gradlew spotbugsMain -PenableSpotbugs --console=plain` *(fails: longstanding warnings elsewhere in the codebase)*
- `./gradlew pmdMain -PenablePmd --console=plain` *(fails: legacy violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f9b727a4832f941947aac59980a1