### PR TITLE
Align manipulator state machine with updated graph

### DIFF
--- a/src/main/java/frc/robot/subsystems/StateMachineCoardinator.java
+++ b/src/main/java/frc/robot/subsystems/StateMachineCoardinator.java
@@ -194,7 +194,7 @@ public class StateMachineCoardinator extends SubsystemBase {
                                 setDriveGoal(DriveState.BARGE_RELATIVE);
                                 break;
                         case CLIMB:
-                                setElevatorManipulatorGoal(ElevatorManipulatorState.CLIMB);
+                                setElevatorManipulatorGoal(ElevatorManipulatorState.CLIMB_READY);
                                 setDriveGoal(DriveState.CLIMB_RELATIVE);
                                 break;
                         case MANUAL:


### PR DESCRIPTION
## Summary
- add climb ready, climbed, and climb abort graph nodes with sequential climb deployment and stow commands
- update algae and barge transitions to include prep low/high loops and a barge post-score node to match the revised diagram
- route the coordinator’s climb request through the new climb-ready state enumeration

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d0753c20d8832faeee78b3184a4a6b