### PR TITLE
GraphCommand update based on other team's update

### DIFF
--- a/src/main/java/frc/robot/commands/GraphCommand.java
+++ b/src/main/java/frc/robot/commands/GraphCommand.java
@@ -166,6 +166,12 @@ public class GraphCommand extends Command {
 
     /** Requests a new target node for the graph to route toward. */
     public void setTargetNode(GraphCommandNode node) {
+        // this is here to prevent a null pointer exception when the default next node
+        // for a node is null
+        if (node == null) {
+            return;
+        }
+
         // if the graph isn't transitioning set the next node and move on
         if (!m_isTransitioning) {
             m_targetNode = node;
@@ -290,6 +296,11 @@ public class GraphCommand extends Command {
          * @return The waypoint to visit next or {@code null} if the node is already at the target.
          */
         public GraphCommandNode getNextNodeGivenTarget(GraphCommandNode node) {
+            // trying to go to null!
+            if (node == null) {
+                return null;
+            }
+
             GraphCommandNodeLink link = m_optimizedLinks.get(node.m_nodeName);
 
             // cannot get to the node


### PR DESCRIPTION
## Summary
- prevent null target requests from triggering GraphCommand rerouting
- make GraphCommandNode return early when asked for a null target node

## Testing
- ./gradlew build *(fails: missing DifferentialArm/Elevator setpoints referenced by other commands)*

------
https://chatgpt.com/codex/tasks/task_e_68d01823b5dc832fb3e4abc59bcb9d8f