### PR TITLE
Use PhotonCamera unread results to avoid deprecation

### DIFF
--- a/src/main/java/frc/utils/VisionUtils.java
+++ b/src/main/java/frc/utils/VisionUtils.java
@@ -8,16 +8,17 @@
 package frc.utils;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import java.util.List;
 import org.photonvision.PhotonCamera;
 import org.photonvision.targeting.PhotonPipelineResult;
 
 /** Thin wrapper around a PhotonCamera that refreshes its latest result each loop. */
 public class VisionUtils extends SubsystemBase {
   /** Underlying PhotonVision camera. */
-  PhotonCamera camera;
+  private final PhotonCamera camera;
 
   /** Cached copy of the most recent pipeline result. */
-  PhotonPipelineResult detections;
+  private PhotonPipelineResult detections = new PhotonPipelineResult();
 
   /** Creates a new VisionUtils. */
   public VisionUtils(String cameraName) {
@@ -25,7 +26,12 @@ public class VisionUtils extends SubsystemBase {
   }
 
   public PhotonPipelineResult getLatestResult() {
-    return camera.getLatestResult();
+    List<PhotonPipelineResult> unreadResults = camera.getAllUnreadResults();
+    if (!unreadResults.isEmpty()) {
+      detections = unreadResults.get(unreadResults.size() - 1);
+    }
+
+    return detections;
   }
 
   @Override


### PR DESCRIPTION
## Summary
- refresh the PhotonCamera wrapper to consume unread results instead of the deprecated getLatestResult API
- cache a default pipeline result so callers always receive the most recent detection data

## Testing
- ./gradlew clean build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d0af8d1a28832fbc448ad55e86ef81