### PR TITLE
Handle missing alliance when initializing PhotonRunnable

### DIFF
--- a/src/main/java/frc/utils/PhotonRunnable.java
+++ b/src/main/java/frc/utils/PhotonRunnable.java
@@ -57,10 +57,16 @@ public class PhotonRunnable implements Runnable {
     PhotonPoseEstimator photonPoseEstimator = null;
     layout = AprilTagFieldLayout.loadField(AprilTagFields.k2025ReefscapeAndyMark);
     // PV estimates will always be blue, they'll get flipped by robot thread
-    layout.setOrigin(OriginPosition.kBlueAllianceWallRightSide);
-    if (DriverStation.getAlliance().get() == Alliance.Red) {
-      layout.setOrigin(OriginPosition.kRedAllianceWallRightSide);
-    }
+    DriverStation.getAlliance()
+        .ifPresentOrElse(
+            alliance -> {
+              if (alliance == Alliance.Red) {
+                layout.setOrigin(OriginPosition.kRedAllianceWallRightSide);
+              } else {
+                layout.setOrigin(OriginPosition.kBlueAllianceWallRightSide);
+              }
+            },
+            () -> layout.setOrigin(OriginPosition.kBlueAllianceWallRightSide));
     if (photonCamera != null) {
       photonPoseEstimator =
           new PhotonPoseEstimator(layout, PoseStrategy.CONSTRAINED_SOLVEPNP, cameraToRobot);


### PR DESCRIPTION
## Summary
- guard the PhotonRunnable field layout origin update with `Optional.ifPresentOrElse`
- fall back to the blue origin when no alliance information is present to avoid Optional#get exceptions

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d0bda1f0b0832fb6d9e4e31fdd5a39