### PR TITLE
Handle PhotonVision frames without targets

### DIFF
--- a/src/main/java/frc/utils/PhotonRunnable.java
+++ b/src/main/java/frc/utils/PhotonRunnable.java
@@ -79,6 +79,9 @@ public class PhotonRunnable implements Runnable {
         photonPoseEstimator.addHeadingData(tempHeading.timestamp, tempHeading.rotation);
         Optional<EstimatedRobotPose> photonPose =
             photonPoseEstimator.update(result, Optional.empty(), Optional.empty(), params);
+        if (!result.hasTargets()) {
+          continue;
+        }
         if (photonPose.isPresent()) {
           double tagDist = result.getBestTarget().bestCameraToTarget.getTranslation().getNorm();
           double poseAmbig = result.getBestTarget().getPoseAmbiguity();


### PR DESCRIPTION
## Summary
- skip PhotonVision pipeline results that report no targets before calling getBestTarget
- keep the existing distance and ambiguity validation for valid targets

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d0be1efe50832f9b0173c428b37eeb