### PR TITLE
Handle null GraphCommand targets gracefully

### DIFF
--- a/src/main/java/frc/robot/commands/GraphCommand.java
+++ b/src/main/java/frc/robot/commands/GraphCommand.java
@@ -167,8 +167,18 @@ public class GraphCommand extends Command {
     return m_currentNode;
   }
 
-  /** Requests a new target node for the graph to route toward. */
+  /**
+   * Requests a new target node for the graph to route toward.
+   *
+   * @param node Target node to reach. {@code null} requests are ignored.
+   */
   public void setTargetNode(GraphCommandNode node) {
+    // this is here to prevent a null pointer exception when the default next node
+    // for a node is null
+    if (node == null) {
+      return;
+    }
+
     // if the graph isn't transitioning set the next node and move on
     if (!m_isTransitioning) {
       m_targetNode = node;
@@ -285,9 +295,15 @@ public class GraphCommand extends Command {
      * Determines the next hop to take when traveling toward the supplied target node.
      *
      * @param node Node to reach.
-     * @return The waypoint to visit next or {@code null} if the node is already at the target.
+     * @return The waypoint to visit next or {@code null} if the node is already at the target,
+     *     unreachable, or not provided.
      */
     public GraphCommandNode getNextNodeGivenTarget(GraphCommandNode node) {
+      // trying to go to null!
+      if (node == null) {
+        return null;
+      }
+
       GraphCommandNodeLink link = m_optimizedLinks.get(node.m_nodeName);
 
       // cannot get to the node


### PR DESCRIPTION
## Summary
- ignore null target requests when retargeting the graph to prevent NPEs
- guard next-node resolution when no target node is supplied and document the behavior

## Testing
- ./gradlew build *(fails: choreo:ChoreoLib-java:2025.0.3 unavailable, HTTP 503)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bee9e2d8832fac6aada32058707e